### PR TITLE
Add support for expressions

### DIFF
--- a/library/Director/CustomVariable/CustomVariable.php
+++ b/library/Director/CustomVariable/CustomVariable.php
@@ -88,12 +88,12 @@ abstract class CustomVariable implements IcingaConfigRenderer
         return $this->modified;
     }
 
-    public function toConfigStringPrefetchable()
+    public function toConfigStringPrefetchable($renderExpressions = false)
     {
         if (PrefetchCache::shouldBeUsed()) {
-            return PrefetchCache::instance()->renderVar($this);
+            return PrefetchCache::instance()->renderVar($this, $renderExpressions);
         } else {
-            return $this->toConfigString();
+            return $this->toConfigString($renderExpressions);
         }
     }
 

--- a/library/Director/CustomVariable/CustomVariableString.php
+++ b/library/Director/CustomVariable/CustomVariableString.php
@@ -36,8 +36,8 @@ class CustomVariableString extends CustomVariable
         return $this;
     }
 
-    public function toConfigString()
+    public function toConfigString($renderExpressions = false)
     {
-        return c::renderString($this->getValue());
+        return c::renderString($this->getValue(), $renderExpressions);
     }
 }

--- a/library/Director/CustomVariable/CustomVariables.php
+++ b/library/Director/CustomVariable/CustomVariables.php
@@ -268,24 +268,24 @@ class CustomVariables implements Iterator, Countable, IcingaConfigRenderer
         return $this->storedVars;
     }
 
-    public function toConfigString()
+    public function toConfigString($renderExpressions = false)
     {
         $out = '';
 
         ksort($this->vars);
         foreach ($this->vars as $key => $var) {
             // TODO: ctype_alnum + underscore?
-            $out .= $this->renderSingleVar($key, $var);
+            $out .= $this->renderSingleVar($key, $var, $renderExpressions);
         }
 
         return $out;
     }
 
-    protected function renderSingleVar($key, $var)
+    protected function renderSingleVar($key, $var, $renderExpressions = false)
     {
         return c::renderKeyValue(
             $this->renderKeyName($key),
-            $var->toConfigStringPrefetchable()
+            $var->toConfigStringPrefetchable($renderExpressions)
         );
     }
 

--- a/library/Director/Db/Cache/PrefetchCache.php
+++ b/library/Director/Db/Cache/PrefetchCache.php
@@ -84,14 +84,14 @@ class PrefetchCache
     }
     */
 
-    public function renderVar(CustomVariable $var)
+    public function renderVar(CustomVariable $var, $renderExpressions = false)
     {
         $checksum = $var->getChecksum();
         if (null === $checksum) {
-            return $var->toConfigString();
+            return $var->toConfigString($renderExpressions);
         } else {
             if (! array_key_exists($checksum, $this->renderedVars)) {
-                $this->renderedVars[$checksum] = $var->toConfigString();
+                $this->renderedVars[$checksum] = $var->toConfigString($renderExpressions);
             }
 
             return $this->renderedVars[$checksum];

--- a/library/Director/IcingaConfig/IcingaConfigHelper.php
+++ b/library/Director/IcingaConfig/IcingaConfigHelper.php
@@ -74,7 +74,7 @@ class IcingaConfigHelper
 
     // TODO: Find out how to allow multiline {{{...}}} strings.
     //       Parameter? Dedicated method? Always if \n is found?
-    public static function renderString($string)
+    public static function renderString($string, $renderExpressions = false)
     {
         $special = array(
             '/\\\/',
@@ -100,7 +100,11 @@ class IcingaConfigHelper
 
         $string = preg_replace($special, $replace, $string);
 
-        return '"' . self::renderVariablesAsExpression($string) . '"';
+        if ($renderExpressions) {
+            return self::renderStringWithVariables($string);
+        } else {
+            return '"' . $string . '"';
+        }
     }
 
     public static function renderDictionaryKey($key)
@@ -258,7 +262,15 @@ class IcingaConfigHelper
         return $seconds . 's';
     }
 
-    private static function renderVariablesAsExpression($string) {
-        return preg_replace('/\$\$([\w\.]+)\$\$/', '" + ${1} + "', $string);
+    private static function renderStringWithVariables($string) {
+        $string = preg_replace('/\$\$([\w\.]+)\$\$/', '" + ${1} + "', $string);
+        $string = '"' . $string . '"';
+        if (substr($string, 0, 5) === '"" + ') {
+            $string = substr($string, 5);
+        }
+        if (substr($string, -5) === ' + ""') {
+            $string = substr($string, 0, -5);
+        }
+        return $string;
     }
 }

--- a/library/Director/IcingaConfig/IcingaConfigHelper.php
+++ b/library/Director/IcingaConfig/IcingaConfigHelper.php
@@ -263,7 +263,7 @@ class IcingaConfigHelper
     }
 
     private static function renderStringWithVariables($string) {
-        $string = preg_replace('/\$\$([\w\.]+)\$\$/', '" + ${1} + "', $string);
+        $string = preg_replace('/(?<!\$)\$([\w\.]+)\$(?!\$)/', '" + ${1} + "', $string);
         $string = '"' . $string . '"';
         if (substr($string, 0, 5) === '"" + ') {
             $string = substr($string, 5);

--- a/library/Director/IcingaConfig/IcingaConfigHelper.php
+++ b/library/Director/IcingaConfig/IcingaConfigHelper.php
@@ -100,7 +100,7 @@ class IcingaConfigHelper
 
         $string = preg_replace($special, $replace, $string);
 
-        return '"' . $string . '"';
+        return '"' . self::renderVariablesAsExpression($string) . '"';
     }
 
     public static function renderDictionaryKey($key)
@@ -256,5 +256,9 @@ class IcingaConfigHelper
         }
 
         return $seconds . 's';
+    }
+
+    private static function renderVariablesAsExpression($string) {
+        return preg_replace('/\$\$([\w\.]+)\$\$/', '" + ${1} + "', $string);
     }
 }

--- a/library/Director/Objects/IcingaObject.php
+++ b/library/Director/Objects/IcingaObject.php
@@ -1616,11 +1616,8 @@ abstract class IcingaObject extends DbObject implements IcingaConfigRenderer
     protected function renderLegacyProperties()
     {
         $out = '';
-        $blacklist = array_merge(array(
-            'id',
-            'object_name',
-            'object_type',
-        ), array() /* $this->prioritizedProperties */);
+        $blacklist = array_merge($this->propertiesNotForRendering,
+            array() /* $this->prioritizedProperties */);
 
         foreach ($this->properties as $key => $value) {
             if (in_array($key, $blacklist)) {
@@ -1691,7 +1688,7 @@ abstract class IcingaObject extends DbObject implements IcingaConfigRenderer
             return $this->renderRelationProperty($relKey, $value);
         }
 
-        return c::renderKeyValue($key, c::renderString($value));
+        return c::renderKeyValue($key, c::renderString($value, $this->isApplyRule()));
     }
 
     protected function renderLegacyObjectProperty($key, $value)
@@ -1768,7 +1765,7 @@ abstract class IcingaObject extends DbObject implements IcingaConfigRenderer
     protected function renderCustomVars()
     {
         if ($this->supportsCustomVars()) {
-            return $this->vars()->toConfigString();
+            return $this->vars()->toConfigString($this->isApplyRule());
         } else {
             return '';
         }

--- a/test/php/library/Director/CustomVariable/CustomVariablesTest.php
+++ b/test/php/library/Director/CustomVariable/CustomVariablesTest.php
@@ -44,6 +44,21 @@ class CustomVariablesTest extends BaseTestCase
         );
     }
 
+    public function testVariablesToExpression()
+    {
+        $vars = $this->newVars();
+        $vars->bla = 'da';
+        $vars->abc = '$$val$$';
+        $expected = $this->indentVarsList(array(
+            'vars.abc = val',
+            'vars.bla = "da"'
+        ));
+        $this->assertEquals(
+            $vars->toConfigString(true),
+            $expected
+        );
+    }
+
     protected function indentVarsList($vars)
     {
         return $this->indent . implode(

--- a/test/php/library/Director/CustomVariable/CustomVariablesTest.php
+++ b/test/php/library/Director/CustomVariable/CustomVariablesTest.php
@@ -48,7 +48,7 @@ class CustomVariablesTest extends BaseTestCase
     {
         $vars = $this->newVars();
         $vars->bla = 'da';
-        $vars->abc = '$$val$$';
+        $vars->abc = '$val$';
         $expected = $this->indentVarsList(array(
             'vars.abc = val',
             'vars.bla = "da"'

--- a/test/php/library/Director/IcingaConfig/IcingaConfigHelperTest.php
+++ b/test/php/library/Director/IcingaConfig/IcingaConfigHelperTest.php
@@ -83,16 +83,19 @@ class IcingaConfigHelperTest extends BaseTestCase
 
     public function testRenderStringWithVariables()
     {
+        $this->assertEquals(c::renderString('Before $$var$$', true), '"Before " + var');
+        $this->assertEquals(c::renderString('$$var$$ After', true), 'var + " After"');
+        $this->assertEquals(c::renderString('$$var$$', true), 'var');
         $this->assertEquals(
-            c::renderString('Before $$name$$ $$name$$ After'),
+            c::renderString('Before $$name$$ $$name$$ After', true),
             '"Before " + name + " " + name + " After"');
         $this->assertEquals(
-            c::renderString('Before $$var1$$ $$var2$$ After'),
+            c::renderString('Before $$var1$$ $$var2$$ After', true),
             '"Before " + var1 + " " + var2 + " After"');
-        $this->assertEquals(c::renderString('$$host.vars.custom$$'), '"" + host.vars.custom + ""');
-        $this->assertEquals(c::renderString('$$var"$$'), '"$$var\"$$"');
+        $this->assertEquals(c::renderString('$$host.vars.custom$$', true), 'host.vars.custom');
+        $this->assertEquals(c::renderString('$$var"$$', true), '"$$var\"$$"');
         $this->assertEquals(
-            c::renderString('\tI am\rrendering\nproperly\fand I $$support$$ "multiple" $$variables$$\$'),
+            c::renderString('\tI am\rrendering\nproperly\fand I $$support$$ "multiple" $$variables$$\$', true),
             '"\\\\tI am\\\\rrendering\\\\nproperly\\\\fand I " + support + " \"multiple\" " + variables + "\\\\$"');
     }
 }

--- a/test/php/library/Director/IcingaConfig/IcingaConfigHelperTest.php
+++ b/test/php/library/Director/IcingaConfig/IcingaConfigHelperTest.php
@@ -69,4 +69,30 @@ class IcingaConfigHelperTest extends BaseTestCase
     {
         return file_get_contents(__DIR__ . '/rendered/' . $name . '.out');
     }
+
+    public function testRenderStringIsCorrectlyRendered()
+    {
+        $this->assertEquals(c::renderString('val1\\\val2'), '"val1\\\\\\\\val2"');
+        $this->assertEquals(c::renderString('"val1"'), '"\"val1\""');
+        $this->assertEquals(c::renderString('\$val\$'), '"\\\\$val\\\\$"');
+        $this->assertEquals(c::renderString('\t'), '"\\\\t"');
+        $this->assertEquals(c::renderString('\r'), '"\\\\r"');
+        $this->assertEquals(c::renderString('\n'), '"\\\\n"');
+        $this->assertEquals(c::renderString('\f'), '"\\\\f"');
+    }
+
+    public function testRenderStringWithVariables()
+    {
+        $this->assertEquals(
+            c::renderString('Before $$name$$ $$name$$ After'),
+            '"Before " + name + " " + name + " After"');
+        $this->assertEquals(
+            c::renderString('Before $$var1$$ $$var2$$ After'),
+            '"Before " + var1 + " " + var2 + " After"');
+        $this->assertEquals(c::renderString('$$host.vars.custom$$'), '"" + host.vars.custom + ""');
+        $this->assertEquals(c::renderString('$$var"$$'), '"$$var\"$$"');
+        $this->assertEquals(
+            c::renderString('\tI am\rrendering\nproperly\fand I $$support$$ "multiple" $$variables$$\$'),
+            '"\\\\tI am\\\\rrendering\\\\nproperly\\\\fand I " + support + " \"multiple\" " + variables + "\\\\$"');
+    }
 }

--- a/test/php/library/Director/IcingaConfig/IcingaConfigHelperTest.php
+++ b/test/php/library/Director/IcingaConfig/IcingaConfigHelperTest.php
@@ -83,19 +83,21 @@ class IcingaConfigHelperTest extends BaseTestCase
 
     public function testRenderStringWithVariables()
     {
-        $this->assertEquals(c::renderString('Before $$var$$', true), '"Before " + var');
-        $this->assertEquals(c::renderString('$$var$$ After', true), 'var + " After"');
-        $this->assertEquals(c::renderString('$$var$$', true), 'var');
+        $this->assertEquals(c::renderString('Before $var$', true), '"Before " + var');
+        $this->assertEquals(c::renderString('$var$ After', true), 'var + " After"');
+        $this->assertEquals(c::renderString('$var$', true), 'var');
+        $this->assertEquals(c::renderString('$$var$$', true), '"$$var$$"');
+        $this->assertEquals(c::renderString('Before $$var$$ After', true), '"Before $$var$$ After"');
         $this->assertEquals(
-            c::renderString('Before $$name$$ $$name$$ After', true),
+            c::renderString('Before $name$ $name$ After', true),
             '"Before " + name + " " + name + " After"');
         $this->assertEquals(
-            c::renderString('Before $$var1$$ $$var2$$ After', true),
+            c::renderString('Before $var1$ $var2$ After', true),
             '"Before " + var1 + " " + var2 + " After"');
-        $this->assertEquals(c::renderString('$$host.vars.custom$$', true), 'host.vars.custom');
-        $this->assertEquals(c::renderString('$$var"$$', true), '"$$var\"$$"');
+        $this->assertEquals(c::renderString('$host.vars.custom$', true), 'host.vars.custom');
+        $this->assertEquals(c::renderString('$var"$', true), '"$var\"$"');
         $this->assertEquals(
-            c::renderString('\tI am\rrendering\nproperly\fand I $$support$$ "multiple" $$variables$$\$', true),
+            c::renderString('\tI am\rrendering\nproperly\fand I $support$ "multiple" $variables$\$', true),
             '"\\\\tI am\\\\rrendering\\\\nproperly\\\\fand I " + support + " \"multiple\" " + variables + "\\\\$"');
     }
 }

--- a/test/php/library/Director/Objects/IcingaServiceTest.php
+++ b/test/php/library/Director/Objects/IcingaServiceTest.php
@@ -242,13 +242,13 @@ class IcingaServiceTest extends BaseTestCase
 
         $db = $this->getDb();
 
-        $service = $this->service('___TEST___service_$$not_replaced$$');
+        $service = $this->service('___TEST___service_$not_replaced$');
         $service->object_type = 'apply';
-        $service->display_name = 'Service: $$replaced$$';
+        $service->display_name = 'Service: $host.vars.replaced$';
         $service->assignments = array(
             'host.address="127.*"',
         );
-        $service->{'vars.custom_var'} = '$$replaced$$';
+        $service->{'vars.custom_var'} = '$host.vars.replaced$';
         $service->store($db);
 
         $service = IcingaService::loadWithAutoIncId($service->id, $db);
@@ -266,10 +266,10 @@ class IcingaServiceTest extends BaseTestCase
 
         $db = $this->getDb();
 
-        $service = $this->service('___TEST___service_$$not_replaced$$');
+        $service = $this->service('___TEST___service_$not_replaced$');
         $service->object_type = 'object';
-        $service->display_name = 'Service: $$not_replaced$$';
-        $service->{'vars.custom_var'} = '$$not_replaced$$';
+        $service->display_name = 'Service: $host.vars.not_replaced$';
+        $service->{'vars.custom_var'} = '$host.vars.not_replaced$';
         $service->store($db);
 
         $service = IcingaService::loadWithAutoIncId($service->id, $db);

--- a/test/php/library/Director/Objects/IcingaServiceTest.php
+++ b/test/php/library/Director/Objects/IcingaServiceTest.php
@@ -12,6 +12,7 @@ class IcingaServiceTest extends BaseTestCase
     protected $testHostName = '___TEST___host';
 
     protected $testServiceName = '___TEST___service';
+    protected $createdServices = [];
 
     public function testUnstoredHostCanBeLazySet()
     {
@@ -233,6 +234,51 @@ class IcingaServiceTest extends BaseTestCase
         );
     }
 
+    public function testVariablesInPropertiesAndCustomVariables()
+    {
+        if ($this->skipForMissingDb()) {
+            return;
+        }
+
+        $db = $this->getDb();
+
+        $service = $this->service('___TEST___service_$$not_replaced$$');
+        $service->object_type = 'apply';
+        $service->display_name = 'Service: $$replaced$$';
+        $service->assignments = array(
+            'host.address="127.*"',
+        );
+        $service->{'vars.custom_var'} = '$$replaced$$';
+        $service->store($db);
+
+        $service = IcingaService::loadWithAutoIncId($service->id, $db);
+        $this->assertEquals(
+            $this->loadRendered('service3'),
+            (string) $service
+        );
+    }
+
+    public function testVariablesAreNotReplacedForNonApplyObjects()
+    {
+        if ($this->skipForMissingDb()) {
+            return;
+        }
+
+        $db = $this->getDb();
+
+        $service = $this->service('___TEST___service_$$not_replaced$$');
+        $service->object_type = 'object';
+        $service->display_name = 'Service: $$not_replaced$$';
+        $service->{'vars.custom_var'} = '$$not_replaced$$';
+        $service->store($db);
+
+        $service = IcingaService::loadWithAutoIncId($service->id, $db);
+        $this->assertEquals(
+            $this->loadRendered('service4'),
+            (string) $service
+        );
+    }
+
     protected function host()
     {
         return IcingaHost::create(array(
@@ -242,10 +288,14 @@ class IcingaServiceTest extends BaseTestCase
         ));
     }
 
-    protected function service()
+    protected function service($objectName = null)
     {
+        if ($objectName === null) {
+            $objectName = $this->testServiceName;
+        }
+        $this->createdServices[] = $objectName;
         return IcingaService::create(array(
-            'object_name'  => $this->testServiceName,
+            'object_name'  => $objectName,
             'object_type'  => 'object',
             'display_name' => 'Whatever service',
             'vars'         => array(
@@ -279,7 +329,7 @@ class IcingaServiceTest extends BaseTestCase
                 }
             }
 
-            $kill = array($this->testServiceName);
+            $kill = $this->createdServices;
             foreach ($kill as $name) {
                 if (IcingaService::exists(array($name), $db)) {
                     IcingaService::load($name, $db)->delete();

--- a/test/php/library/Director/Objects/rendered/service3.out
+++ b/test/php/library/Director/Objects/rendered/service3.out
@@ -1,0 +1,16 @@
+apply Service "___TEST___service_$$not_replaced$$" {
+    display_name = "Service: " + replaced
+    vars.custom_var = replaced
+    vars.test1 = "string"
+    vars.test2 = 17
+    vars.test3 = false
+    vars.test4 = {
+        a = [ "dict", "ionary" ]
+        @this = "is"
+    }
+
+    assign where match("127.*", host.address)
+
+    import "host var overrides (Director)"
+}
+

--- a/test/php/library/Director/Objects/rendered/service3.out
+++ b/test/php/library/Director/Objects/rendered/service3.out
@@ -1,6 +1,6 @@
-apply Service "___TEST___service_$$not_replaced$$" {
-    display_name = "Service: " + replaced
-    vars.custom_var = replaced
+apply Service "___TEST___service_$not_replaced$" {
+    display_name = "Service: " + host.vars.replaced
+    vars.custom_var = host.vars.replaced
     vars.test1 = "string"
     vars.test2 = 17
     vars.test3 = false
@@ -11,6 +11,6 @@ apply Service "___TEST___service_$$not_replaced$$" {
 
     assign where match("127.*", host.address)
 
-    import "host var overrides (Director)"
+    import DirectorOverrideTemplate
 }
 

--- a/test/php/library/Director/Objects/rendered/service4.out
+++ b/test/php/library/Director/Objects/rendered/service4.out
@@ -1,6 +1,6 @@
-object Service "___TEST___service_$$not_replaced$$" {
-    display_name = "Service: $$not_replaced$$"
-    vars.custom_var = "$$not_replaced$$"
+object Service "___TEST___service_$not_replaced$" {
+    display_name = "Service: $host.vars.not_replaced$"
+    vars.custom_var = "$host.vars.not_replaced$"
     vars.test1 = "string"
     vars.test2 = 17
     vars.test3 = false

--- a/test/php/library/Director/Objects/rendered/service4.out
+++ b/test/php/library/Director/Objects/rendered/service4.out
@@ -1,0 +1,12 @@
+object Service "___TEST___service_$$not_replaced$$" {
+    display_name = "Service: $$not_replaced$$"
+    vars.custom_var = "$$not_replaced$$"
+    vars.test1 = "string"
+    vars.test2 = 17
+    vars.test3 = false
+    vars.test4 = {
+        a = [ "dict", "ionary" ]
+        @this = "is"
+    }
+}
+


### PR DESCRIPTION
Any rendered string can contain variables encapsulated with "$$" characters

Example:
Display Name declared with `Port $$host.vars.tcp_port$$ check` will
be processed as `"Port " + host.vars.tcp_port + " check"`

API:
```bash
 ./director-curl POST director/service?name=my_service '{"display_name": "Port $$host.vars.tcp_port$$ check" }'
 ```

 Rendered config:
 ```
  apply Service "my_service" {
      import "my_template"

      display_name = "Port " + host.vars.tcp_port + " check"
  }
 ```

This feature will be needed to add support of Service Apply Rules. See https://dev.icinga.org/issues/11976

Custom handling with $$var$$ was prefered over native Icinga 2 macro support (`$var$` or `macro($var$)`) because macro doesn't resolve variables declared in apply for rules. 

E.g:
With `apply Service "name" for (config => host.vars.configs)`, `config` won't be resolvable with either `"$config$"` or `macro("$config$")`

refs #11976