### PR TITLE
Include the Icinga 2 Windows plugins by default in powershell script.

### DIFF
--- a/contrib/windows-agent-installer/Icinga2Agent.psm1
+++ b/contrib/windows-agent-installer/Icinga2Agent.psm1
@@ -531,6 +531,7 @@ function Icinga2AgentModule {
 include "constants.conf"
 include <itl>
 include <plugins>
+include <windows-plugins>
 // include <plugins-contrib>
 if (!globals.contains("NscpPath")) {
   NscpPath = dirname(msi_get_component_path("{5C45463A-4AE9-4325-96DB-6E239C034F93}"))


### PR DESCRIPTION
Im not sure if this was wanted by the author, but i am not possbile to execute windows check commands (i.e. service-windows) on my client without this include.
