### PR TITLE
Added support for array of any Datafield

### DIFF
--- a/application/views/helpers/FormMetaArray.php
+++ b/application/views/helpers/FormMetaArray.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * View helper for meta arrays
+ *
+ * @codingStandardsIgnoreStart
+ */
+class Zend_View_Helper_FormMetaArray extends Zend_View_Helper_FormElement
+{
+    public function formMetaArray($name, $values = null, $attribs = null, $options = null, $listsep = null)
+    {
+        $info = $this->_getInfo($name, $values, $attribs, $options, $listsep);
+
+        extract($info); // name, value, attribs, options, listsep, disable
+
+        $subElement = $attribs['subElement'];
+        $subElement->setIsArray(true);
+        $elements = [];
+
+        if ($values) {
+            foreach($values as $index => $subValue) {
+                $subElement->setValue($subValue);
+                $elements[] = $subElement->renderViewHelper();
+            }
+        }
+
+        $subElement->setValue(null);
+        $subElement->setAttrib('placeholder', 'Add...');
+        $elements[] = $subElement->renderViewHelper();
+
+        return implode('', $elements);
+    }
+}

--- a/library/Director/DataType/DataTypeMetaArray.php
+++ b/library/Director/DataType/DataTypeMetaArray.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Icinga\Module\Director\DataType;
+
+use Icinga\Module\Director\Hook\DataTypeHook;
+use Icinga\Module\Director\Objects\DirectorDatafield;
+use Icinga\Module\Director\Web\Form\QuickForm;
+
+class DataTypeMetaArray extends DataTypeHook
+{
+    public function getFormElement($name, QuickForm $form)
+    {
+        $element = $form->createElement('metaArray', $name);
+
+        $datafield = DirectorDatafield::load($this->getSetting('metatype_id'), $form->getDb());
+        $element->subElement = $datafield->getFormElement($form, $name);
+
+        return $element;
+    }
+
+    public static function addSettingsFormFields(QuickForm $form)
+    {
+        $db = $form->getDb();
+
+        $form->addElement('select', 'metatype_id', array(
+            'label'    => 'Content type',
+            'required' => true,
+            'multiOptions' => array(null => '- please choose -') + $db->enumDatafields(),
+        ));
+        return $form;
+    }
+}

--- a/library/Director/Web/Form/Element/MetaArray.php
+++ b/library/Director/Web/Form/Element/MetaArray.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Icinga\Module\Director\Web\Form\Element;
+
+class MetaArray extends FormElement
+{
+    public $helper = 'formMetaArray';
+
+    /**
+     * Always ignore this element
+     * @codingStandardsIgnoreStart
+     *
+     * @var boolean
+     */
+    protected $_ignore = true;
+    // @codingStandardsIgnoreEnd
+
+    public function isValid($values, $context = null)
+    {
+        if ($values === null) {
+            return true;
+        }
+
+        $subElement = $this->getAttrib('subElement');
+
+        foreach ($values as $value) {
+            if ( ! $subElement->isValid($value)) {
+                $this->addError(sprintf("'%s' is invalid", $value));
+                return false;
+            }
+        }
+        return true;
+    }
+
+    public function setValue($values) {
+        $filteredValues = [];
+        $subElement = $this->getAttrib('subElement');
+
+        foreach ($values as $subValue) {
+            $subValue = $subElement->setValue($subValue)->getValue();
+            if ($subValue) {
+                $filteredValues[] = $subValue;
+            }
+        }
+        return parent::setValue($filteredValues);
+    }
+
+    public function getValue()
+    {
+        $value = parent::getValue();
+
+        if (empty($value)) {
+            return null;
+        }
+        return $value;
+    }
+
+    protected function _getErrorMessages()
+    {
+        return $this->getErrorMessages();
+    }
+}

--- a/run.php
+++ b/run.php
@@ -18,6 +18,7 @@ $this->provideHook('director/DataType', $prefix . 'DataType\\DataTypeNumber');
 $this->provideHook('director/DataType', $prefix . 'DataType\\DataTypeDirectorObject');
 $this->provideHook('director/DataType', $prefix . 'DataType\\DataTypeSqlQuery');
 $this->provideHook('director/DataType', $prefix . 'DataType\\DataTypeString');
+$this->provideHook('director/DataType', $prefix . 'DataType\\DataTypeMetaArray');
 
 $this->provideHook('director/PropertyModifier', $prefix . 'PropertyModifier\\PropertyModifierLowercase');
 $this->provideHook('director/PropertyModifier', $prefix . 'PropertyModifier\\PropertyModifierRegexReplace');


### PR DESCRIPTION
Here's the first draft of the "Array of anything" datafield. The way I did it, is by using Datafields instead of Datatypes. By doing it like, we make it compatible with more complex types such as Dictionaries or Datalist.

To use it, you have to declare a "unit" field, like a `DataTypeNumber` for instance.
After that, you can declare your "meta-array" field by creating a `DataTypeMetaArray` field, and in the settings subform, you will be able to say "I want an array of `port (DataTypeNumber)`.

On the other side, when you actually use the field, it simply renders the fields using the proper form element.

Pros:
- it works well, even with our dictionaries
- fairly simple (4 files)

Cons:
- a bit hackish, I don't like to carry `fakeElement/subElement` all over the place just to validate stuff or render the form
-  not unit tested, waiting for inputs on that
