### PR TITLE
PowerShell 2.x and Windows 32bit support

### DIFF
--- a/contrib/windows-agent-installer/Icinga2Agent.psm1
+++ b/contrib/windows-agent-installer/Icinga2Agent.psm1
@@ -276,20 +276,18 @@ function Icinga2AgentModule {
         if (-Not $this.config('agent_version')) {
             return;
         }
-        $WebStatusCode = 0;
         $url = $this.config('download_url') + $this.getProperty('install_msi_package');
         $this.info('Downloading Icinga 2 Agent Binary from ' + $url + '  ...');
-        $execptionMsg = '';
-        Try {
-            $WebStatusCode = Invoke-WebRequest -UseBasicParsing -Method Head -Uri "$url"
 
-            if ($WebStatusCode.StatusCode -eq 200) {
-                Invoke-WebRequest "$url" -OutFile $this.getInstallerPath();
-            } else {
-                throw 'Failed to download Icinga 2 Agent Installer from URL';
+        Try {
+            $client = new-object System.Net.WebClient;
+            $client.DownloadFile($url, $this.getInstallerPath());
+
+            if (-Not $this.installerExists()) {
+                throw 'Unable to locate downloaded Icinga 2 Agent installer file from ' + $url + '. Download destination: ' + $this.getInstallerPath();
             }
         } catch {
-             throw 'Unable to download Icinga 2 Agent from ' + $url + '. Error: ' + $_.Exception.Message;
+            throw 'Unable to download Icinga 2 Agent from ' + $url + '. Please ensure the link does exist and access is possible. Error: ' + $_.Exception.Message;
         }
     }
 

--- a/contrib/windows-agent-installer/Icinga2Agent.psm1
+++ b/contrib/windows-agent-installer/Icinga2Agent.psm1
@@ -276,18 +276,20 @@ function Icinga2AgentModule {
         if (-Not $this.config('agent_version')) {
             return;
         }
+        $WebStatusCode = 0;
         $url = $this.config('download_url') + $this.getProperty('install_msi_package');
         $this.info('Downloading Icinga 2 Agent Binary from ' + $url + '  ...');
-
+        $execptionMsg = '';
         Try {
-            $client = new-object System.Net.WebClient;
-            $client.DownloadFile($url, $this.getInstallerPath());
+            $WebStatusCode = Invoke-WebRequest -UseBasicParsing -Method Head -Uri "$url"
 
-            if (-Not $this.installerExists()) {
-                throw 'Unable to locate downloaded Icinga 2 Agent installer file from ' + $url + '. Download destination: ' + $this.getInstallerPath();
+            if ($WebStatusCode.StatusCode -eq 200) {
+                Invoke-WebRequest "$url" -OutFile $this.getInstallerPath();
+            } else {
+                throw 'Failed to download Icinga 2 Agent Installer from URL';
             }
         } catch {
-            throw 'Unable to download Icinga 2 Agent from ' + $url + '. Please ensure the link does exist and access is possible. Error: ' + $_.Exception.Message;
+             throw 'Unable to download Icinga 2 Agent from ' + $url + '. Error: ' + $_.Exception.Message;
         }
     }
 

--- a/contrib/windows-agent-installer/Icinga2Agent.psm1
+++ b/contrib/windows-agent-installer/Icinga2Agent.psm1
@@ -276,20 +276,18 @@ function Icinga2AgentModule {
         if (-Not $this.config('agent_version')) {
             return;
         }
-        $WebStatusCode = 0;
         $url = $this.config('download_url') + $this.getProperty('install_msi_package');
         $this.info('Downloading Icinga 2 Agent Binary from ' + $url + '  ...');
-        $execptionMsg = '';
-        Try {
-            $WebStatusCode = Invoke-WebRequest -UseBasicParsing -Method Head -Uri "$url"
 
-            if ($WebStatusCode.StatusCode -eq 200) {
-                Invoke-WebRequest "$url" -OutFile $this.getInstallerPath();
-            } else {
-                throw 'Failed to download Icinga 2 Agent Installer from URL';
+        Try {
+            $client = new-object System.Net.WebClient;
+            $client.DownloadFile($url, $this.getInstallerPath());
+
+            if (-Not $this.installerExists()) {
+                throw 'Unable to locate downloaded Icinga 2 Agent installer file from ' + $url + '. Download destination: ' + $this.getInstallerPath();
             }
         } catch {
-             throw 'Unable to download Icinga 2 Agent from ' + $url + '. Error: ' + $_.Exception.Message;
+            throw 'Unable to download Icinga 2 Agent from ' + $url + '. Please ensure the link does exist and access is possible. Error: ' + $_.Exception.Message;
         }
     }
 
@@ -382,7 +380,7 @@ function Icinga2AgentModule {
         $architecture = '';
         $icingaInstallerName = '';
         if ([IntPtr]::Size -eq 4) {
-            $defaultInstallDir = ${Env:ProgramFiles(x86)} + "\ICINGA2";
+            $defaultInstallDir = ${Env:ProgramFiles} + "\ICINGA2";
             $architecture = "x86";
             $regPath = 'HKLM:\Software\Microsoft\Windows\CurrentVersion\Uninstall\*';
         } else {


### PR DESCRIPTION
There was an issue with downloading the Icinga 2 Agent on PowerShell 2.x as the Invoke-WebRequest function does not exist there.

Furthermore there was a problem with the detection of the default install dir on 32bit Windows systems because of a wrong environment variable.