### PR TITLE
Update IcingaServiceForm.php

### DIFF
--- a/application/forms/IcingaServiceForm.php
+++ b/application/forms/IcingaServiceForm.php
@@ -185,10 +185,10 @@ class IcingaServiceForm extends DirectorObjectForm
     {
         $this->addHidden('host_id', $this->host->id);
         $this->addHidden('object_type', 'object');
-        $this->addImportsElement();
+        $this->addImportsElement(false);
         $imports = $this->getSentOrObjectValue('imports');
 
-        if ($this->hasBeenSent()) {
+        if ($this->hasBeenSent() && $this->getElement('imports') !== null) {
             $imports = $this->getElement('imports')->setValue($imports)->getValue();
         }
 


### PR DESCRIPTION
Creating host and service assigned to host:
- `curl -X PUT -H 'Accept: application/json' -u 'admin:admin' -d '{"object_name": "my_host", "check_command": "hostalive", "address": "54.93.143.176", "object_type": "object"}' http://localhost/icingaweb2/director/host`
- `curl -X PUT -H 'Accept: application/json' -u 'admin:admin' -d '{"object_name": "ssh", "check_command": "ssh", "host": "my_host", "object_type": "object"}' http://localhost/icingaweb2/director/service`

Not using service templates at all.

For example, I want to disable this service for this host. I do:
- Browser, http://localhost/icingaweb2
- Icinga Director -> Hosts -> my_host -> Services tab in the second panel -> "ssh" in "Individual Service objects"
- Setting "Disabled" to "Yes" and clicking on "Store"
- Error:

> Fatal error: Call to a member function setValue() on null in /usr/share/icingaweb2/modules/director/application/forms/IcingaServiceForm.php on line 192 

Patch below fixes this error and make template importing optional in setupHostRelatedElements function (not to show red box).