### PR TITLE
Include plugins-contrib by default for Linux agents

### DIFF
--- a/contrib/linux-agent-installer/Icinga2Agent.bash
+++ b/contrib/linux-agent-installer/Icinga2Agent.bash
@@ -77,7 +77,7 @@ include "features-enabled/*.conf"
 
 include <itl>
 include <plugins>
-// include <plugins-contrib>
+include <plugins-contrib>
 EOF
 `
 ZONES_ICINGA2=`cat << EOF


### PR DESCRIPTION
This makes it easier to deploy CheckCommands out-of-the box where the Icinga Director already uses them from the master, but requiring them on the client as well.