### PR TITLE
QuickTable: Fix enforced filters for non-FilterAnd filters

### DIFF
--- a/library/Director/Web/Table/QuickTable.php
+++ b/library/Director/Web/Table/QuickTable.php
@@ -195,7 +195,7 @@ abstract class QuickTable implements Paginatable
         }
         if ($filter) {
             foreach ($enforced as $f) {
-                $filter->andFilter($f);
+                $filter = $filter->andFilter($f);
             }
             $query->where($this->renderFilter($filter));
         }


### PR DESCRIPTION
We need to use the result of andFilter() as the new Filter.

The filter gets replaced by FilterAnd($oldFilter, $enforcedFilter) here.

Please also cherry-pick in 1.3.x