### PR TITLE
DbObject: Don't confuse ids and object_names

### DIFF
--- a/library/Director/Data/Db/DbObject.php
+++ b/library/Director/Data/Db/DbObject.php
@@ -1011,6 +1011,14 @@ abstract class DbObject
 
     public static function loadWithAutoIncId($id, DbConnection $connection)
     {
+        /* Need to cast to int, otherwise the id will be matched against
+         * object_name, which may wreak havoc if an object has a
+         * object_name matching some id. Note that DbObject::set() and
+         * DbObject::setDbProperties() will convert any property to
+         * string, including ids.
+         */
+        $id = (int) $id;
+
         if ($prefetched = static::getPrefetched($id)) {
             return $prefetched;
         }


### PR DESCRIPTION
fixes #992