### PR TITLE
Sync: Respect the fields used in filter_expression of the SyncRule

### DIFF
--- a/library/Director/Import/Sync.php
+++ b/library/Director/Import/Sync.php
@@ -283,6 +283,12 @@ class Sync
                     $filterColumns[$column] = $column;
                 }
             }
+            if (($ruleFilter = $this->rule->filter()) !== null) {
+                foreach ($ruleFilter->listFilteredColumns() as $column) {
+                    $filterColumns[$column] = $column;
+                }
+            }
+
             if (! empty($filterColumns)) {
                 foreach (SyncUtils::getRootVariables($filterColumns) as $column) {
                     $usedColumns[$column] = $column;

--- a/library/Director/Objects/SyncRule.php
+++ b/library/Director/Objects/SyncRule.php
@@ -203,7 +203,10 @@ class SyncRule extends DbObject
         return $this->sync;
     }
 
-    protected function filter()
+    /**
+     * @return Filter
+     */
+    public function filter()
     {
         if ($this->filter === null) {
             $this->filter = Filter::fromQueryString($this->get('filter_expression'));

--- a/library/Director/Test/ImportSourceDummy.php
+++ b/library/Director/Test/ImportSourceDummy.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Icinga\Module\Director\Test;
+
+use Icinga\Module\Director\Hook\ImportSourceHook;
+
+class ImportSourceDummy extends ImportSourceHook
+{
+    protected static $rows = array();
+
+    /**
+     * Returns an array containing importable objects
+     *
+     * @return array
+     */
+    public function fetchData()
+    {
+        return self::$rows;
+    }
+
+    /**
+     * Returns a list of all available columns
+     *
+     * @return array
+     */
+    public function listColumns()
+    {
+        $keys = array();
+        foreach (self::$rows as $row) {
+            $keys = array_merge($keys, array_keys($row));
+        }
+        return $keys;
+    }
+
+    public static function clearRows()
+    {
+        self::$rows = array();
+    }
+
+    public static function setRows($rows)
+    {
+        static::clearRows();
+        foreach ($rows as $row) {
+            static::addRow($row);
+        }
+    }
+
+    public static function addRow($row)
+    {
+        self::$rows[] = (object) $row;
+    }
+}

--- a/library/Director/Test/SyncTest.php
+++ b/library/Director/Test/SyncTest.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace Icinga\Module\Director\Test;
+
+use Icinga\Exception\IcingaException;
+use Icinga\Module\Director\Data\Db\DbObject;
+use Icinga\Module\Director\Db\Cache\PrefetchCache;
+use Icinga\Module\Director\Import\Sync;
+use Icinga\Module\Director\Objects\IcingaObject;
+use Icinga\Module\Director\Objects\ImportSource;
+use Icinga\Module\Director\Objects\SyncProperty;
+use Icinga\Module\Director\Objects\SyncRule;
+
+abstract class SyncTest extends BaseTestCase
+{
+    protected $objectType;
+    
+    protected $keyColumn;
+    
+    /** @var  ImportSource */
+    protected $source;
+
+    /** @var  SyncRule */
+    protected $rule;
+
+    /** @var  SyncProperty[] */
+    protected $properties = array();
+
+    /** @var  Sync */
+    protected $sync;
+
+    public function setUp()
+    {
+        $this->source = ImportSource::create(array(
+            'source_name'    => 'testimport',
+            'provider_class' => 'Icinga\\Module\\Director\\Test\\ImportSourceDummy',
+            'key_column'     => $this->keyColumn,
+        ));
+        $this->source->store($this->getDb());
+
+        $this->rule = SyncRule::create(array(
+            'rule_name'      => 'testrule',
+            'object_type'    => $this->objectType,
+            'update_policy'  => 'merge',
+            'purge_existing' => 'n'
+        ));
+        $this->rule->store($this->getDb());
+
+        $this->sync = new Sync($this->rule);
+    }
+
+    public function tearDown()
+    {
+        // properties should be deleted automatically
+        if ($this->rule !== null && $this->rule->hasBeenLoadedFromDb()) {
+            $this->rule->delete();
+        }
+
+        if ($this->source !== null && $this->source->hasBeenLoadedFromDb()) {
+            $this->source->delete();
+        }
+
+        // find objects created by this class and delete them
+        $db = $this->getDb();
+        $dummy = IcingaObject::createByType($this->objectType, array(), $db);
+        $query = $db->getDbAdapter()->select()
+            ->from($dummy->getTableName())
+            ->where('object_name LIKE ?', 'SYNCTEST_%');
+
+        /** @var IcingaObject $object */
+        foreach (IcingaObject::loadAllByType($this->objectType, $db, $query) as $object) {
+            $object->delete();
+        }
+
+        // make sure cache is clean for other tests
+        PrefetchCache::forget();
+        DbObject::clearAllPrefetchCaches();
+    }
+
+    /**
+     * @param array $rows
+     *
+     * @throws IcingaException
+     */
+    protected function runImport($rows)
+    {
+        ImportSourceDummy::setRows($rows);
+        $this->source->runImport();
+        if ($this->source->get('import_state') !== 'in-sync') {
+            throw new IcingaException('Import failed: %s', $this->source->get('last_error_message'));
+        }
+    }
+
+    protected function setUpProperty($properties = array())
+    {
+        $properties = array_merge(array(
+            'rule_id'      => $this->rule->id,
+            'source_id'    => $this->source->id,
+            'merge_policy' => 'override',
+        ), $properties);
+
+        $this->properties[] = $property = SyncProperty::create($properties);
+        $property->store($this->getDb());
+    }
+}

--- a/schema/pgsql-migrations/upgrade_142.sql
+++ b/schema/pgsql-migrations/upgrade_142.sql
@@ -1,0 +1,13 @@
+ALTER TABLE import_run
+  DROP CONSTRAINT import_run_source;
+
+ALTER TABLE import_run
+  ADD CONSTRAINT import_run_source
+    FOREIGN KEY (source_id)
+    REFERENCES import_source (id)
+    ON DELETE CASCADE
+    ON UPDATE RESTRICT;
+
+INSERT INTO director_schema_migration
+  (schema_version, migration_time)
+  VALUES (142, NOW());

--- a/schema/pgsql.sql
+++ b/schema/pgsql.sql
@@ -1450,8 +1450,8 @@ CREATE TABLE import_run (
   CONSTRAINT import_run_source
   FOREIGN KEY (source_id)
   REFERENCES import_source (id)
-  ON DELETE RESTRICT
-  ON UPDATE CASCADE,
+  ON DELETE CASCADE
+  ON UPDATE RESTRICT,
   CONSTRAINT import_run_rowset
   FOREIGN KEY (rowset_checksum)
   REFERENCES imported_rowset (checksum)
@@ -1841,4 +1841,4 @@ CREATE INDEX user_resolved_var_schecksum ON icinga_user_resolved_var (checksum);
 
 INSERT INTO director_schema_migration
   (schema_version, migration_time)
-  VALUES (141, NOW());
+  VALUES (142, NOW());

--- a/test/php/library/Director/Import/HostSyncTest.php
+++ b/test/php/library/Director/Import/HostSyncTest.php
@@ -1,0 +1,144 @@
+<?php
+
+namespace Tests\Icinga\Module\Director\IcingaConfig;
+
+use Icinga\Module\Director\Objects\IcingaObject;
+use Icinga\Module\Director\Test\SyncTest;
+
+class HostSyncTest extends SyncTest
+{
+    protected $objectType = 'host';
+
+    protected $keyColumn = 'host';
+
+    public function testSimpleSync()
+    {
+        $this->runImport(array(
+            array(
+                'host'    => 'SYNCTEST_simple',
+                'address' => '127.0.0.1',
+                'os'      => 'Linux'
+            )
+        ));
+
+        $this->setUpProperty(array(
+            'source_expression' => '${host}',
+            'destination_field' => 'object_name',
+        ));
+        $this->setUpProperty(array(
+            'source_expression' => '${address}',
+            'destination_field' => 'address',
+        ));
+        $this->setUpProperty(array(
+            'source_expression' => '${os}',
+            'destination_field' => 'vars.os',
+        ));
+
+        $this->assertTrue($this->sync->hasModifications(), 'Should have modifications pending');
+        $this->assertGreaterThan(0, $this->sync->apply(), 'Should successfully apply at least 1 update');
+        $this->assertFalse($this->sync->hasModifications(), 'Should not have modifications pending after sync');
+    }
+
+    public function testSyncWithoutData()
+    {
+        $this->runImport(array());
+
+        $this->setUpProperty(array(
+            'source_expression' => '${host}',
+            'destination_field' => 'object_name',
+        ));
+
+        $this->assertFalse($this->sync->hasModifications(), 'Should not have modifications pending');
+    }
+
+    public function testSyncFilteredData()
+    {
+        $this->runImport(array(
+            array(
+                'host'    => 'SYNCTEST_filtered_in',
+                'address' => '127.0.0.1',
+                'os'      => 'Linux'
+            ),
+            array(
+                'host'    => 'SYNCTEST_filtered_out',
+                'address' => '127.0.0.1',
+                'os'      => null
+            ),
+            array(
+                'host'    => 'SYNCTEST_filtered_in_unusedfield',
+                'address' => '127.0.0.1',
+                'os'      => null,
+                'other'   => '1'
+            ),
+            array(
+                'host'    => 'SYNCTEST_filtered_in_unusedfield_propfilter',
+                'address' => '127.0.0.1',
+                'os'      => null,
+                'other'   => '1',
+                'magic'   => '2',
+            )
+        ));
+
+        $this->rule->set('filter_expression', 'other!=|os=Linux');
+        $this->rule->store();
+
+        $this->setUpProperty(array(
+            'source_expression' => '${host}',
+            'destination_field' => 'object_name',
+        ));
+        $this->setUpProperty(array(
+            'source_expression' => '${address}',
+            'destination_field' => 'address',
+        ));
+        $this->setUpProperty(array(
+            'source_expression' => 'test-${other}',
+            'destination_field' => 'vars.other',
+            'filter_expression' => 'magic!='
+        ));
+
+        $modifications = array();
+        /** @var IcingaObject $mod */
+        foreach ($this->sync->getExpectedModifications() as $mod) {
+            $name = $mod->object_name;
+            $modifications[$name] = $mod;
+
+            $this->assertEquals(
+                '127.0.0.1',
+                $mod->get('address'),
+                $name . ': address should not be synced'
+            );
+            $this->assertNull($mod->get('vars.os'), $name . ': vars.os should not be synced');
+
+            if ($name === 'SYNCTEST_filtered_in_unusedfield_propfilter') {
+                $this->assertEquals(
+                    'test-1',
+                    $mod->get('vars.other'),
+                    $name . ': vars.other should not be synced'
+                );
+            } else {
+                $this->assertNull($mod->get('vars.other'), $name . ': vars.other should not be synced');
+            }
+        }
+
+        $this->assertArrayHasKey(
+            'SYNCTEST_filtered_in',
+            $modifications,
+            'SYNCTEST_filtered_in should be modified'
+        );
+        $this->assertArrayNotHasKey(
+            'SYNCTEST_filtered_out',
+            $modifications,
+            'SYNCTEST_filtered_out should be synced'
+        );
+        $this->assertArrayHasKey(
+            'SYNCTEST_filtered_in_unusedfield',
+            $modifications,
+            'SYNCTEST_filtered_in_unusedfield should be modified'
+        );
+        $this->assertArrayHasKey(
+            'SYNCTEST_filtered_in_unusedfield_propfilter',
+            $modifications,
+            'SYNCTEST_filtered_in_unusedfield_propfilter should be modified'
+        );
+    }
+}

--- a/test/php/library/Director/Import/HostSyncTest.php
+++ b/test/php/library/Director/Import/HostSyncTest.php
@@ -24,14 +24,17 @@ class HostSyncTest extends SyncTest
         $this->setUpProperty(array(
             'source_expression' => '${host}',
             'destination_field' => 'object_name',
+            'priority'          => 10,
         ));
         $this->setUpProperty(array(
             'source_expression' => '${address}',
             'destination_field' => 'address',
+            'priority'          => 11,
         ));
         $this->setUpProperty(array(
             'source_expression' => '${os}',
             'destination_field' => 'vars.os',
+            'priority'          => 12,
         ));
 
         $this->assertTrue($this->sync->hasModifications(), 'Should have modifications pending');
@@ -46,6 +49,7 @@ class HostSyncTest extends SyncTest
         $this->setUpProperty(array(
             'source_expression' => '${host}',
             'destination_field' => 'object_name',
+            'priority'          => 10,
         ));
 
         $this->assertFalse($this->sync->hasModifications(), 'Should not have modifications pending');
@@ -57,43 +61,50 @@ class HostSyncTest extends SyncTest
             array(
                 'host'    => 'SYNCTEST_filtered_in',
                 'address' => '127.0.0.1',
-                'os'      => 'Linux'
+                'os'      => 'Linux',
+                'sync'    => 'yes'
             ),
             array(
                 'host'    => 'SYNCTEST_filtered_out',
                 'address' => '127.0.0.1',
-                'os'      => null
+                'os'      => null,
+                'sync'    => 'no'
             ),
             array(
-                'host'    => 'SYNCTEST_filtered_in_unusedfield',
-                'address' => '127.0.0.1',
-                'os'      => null,
-                'other'   => '1'
+                'host'      => 'SYNCTEST_filtered_in_unusedfield',
+                'address'   => '127.0.0.1',
+                'os'        => null,
+                'sync'      => 'no',
+                'othersync' => '1'
             ),
             array(
-                'host'    => 'SYNCTEST_filtered_in_unusedfield_propfilter',
-                'address' => '127.0.0.1',
-                'os'      => null,
-                'other'   => '1',
-                'magic'   => '2',
+                'host'      => 'SYNCTEST_filtered_in_unusedfield_propfilter',
+                'address'   => '127.0.0.1',
+                'os'        => null,
+                'magic'     => '2',
+                'sync'      => 'no',
+                'othersync' => '1'
             )
         ));
 
-        $this->rule->set('filter_expression', 'other!=|os=Linux');
+        $this->rule->set('filter_expression', 'sync=yes|othersync=1');
         $this->rule->store();
 
         $this->setUpProperty(array(
             'source_expression' => '${host}',
             'destination_field' => 'object_name',
+            'priority'          => 10,
         ));
         $this->setUpProperty(array(
             'source_expression' => '${address}',
             'destination_field' => 'address',
+            'priority'          => 11,
         ));
         $this->setUpProperty(array(
-            'source_expression' => 'test-${other}',
-            'destination_field' => 'vars.other',
-            'filter_expression' => 'magic!='
+            'source_expression' => 'test',
+            'destination_field' => 'vars.magic',
+            'filter_expression' => 'magic!=',
+            'priority'          => 12,
         ));
 
         $modifications = array();
@@ -111,12 +122,12 @@ class HostSyncTest extends SyncTest
 
             if ($name === 'SYNCTEST_filtered_in_unusedfield_propfilter') {
                 $this->assertEquals(
-                    'test-1',
-                    $mod->get('vars.other'),
-                    $name . ': vars.other should not be synced'
+                    'test',
+                    $mod->get('vars.magic'),
+                    $name . ': vars.magic should not be synced'
                 );
             } else {
-                $this->assertNull($mod->get('vars.other'), $name . ': vars.other should not be synced');
+                $this->assertNull($mod->get('vars.magic'), $name . ': vars.magic should not be synced');
             }
         }
 


### PR DESCRIPTION
So that you can filter by fields not used in properties, or in property filters.

fixes #1130
refs #876 

Also fixes #1141 for tests