### PR TITLE
Update 70-REST-API.md

### DIFF
--- a/doc/70-REST-API.md
+++ b/doc/70-REST-API.md
@@ -540,6 +540,7 @@ A new node will `POST` to `self-service/register-host`, with two parameters in
 the URL:
 
 * `name`: it's desired object name, usually the FQDN
+* `object_name`: Name that will be displayed
 * `key`: a valid Host Template API key
 
 In it's body it is allowed to specify a specific set of properties. At the time


### PR DESCRIPTION
Variable "object_name" is needed to register a new host via the self-service API.