### PR TITLE
Dependencies: add usage overview and table

### DIFF
--- a/library/Director/Web/Table/DependencyTemplateUsageTable.php
+++ b/library/Director/Web/Table/DependencyTemplateUsageTable.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Icinga\Module\Director\Web\Table;
+
+class DependencyTemplateUsageTable extends TemplateUsageTable
+{
+    public function getTypes()
+    {
+        return [
+            'templates'  => $this->translate('Templates'),
+            'applyrules' => $this->translate('Apply Rules'),
+        ];
+    }
+
+    protected function getTypeSummaryDefinitions()
+    {
+        return [
+            'templates'  => $this->getSummaryLine('template'),
+            'applyrules' => $this->getSummaryLine('apply'),
+        ];
+    }
+}


### PR DESCRIPTION
the usage table for dependency templates is missing so i've just added them :wink: 

![dependencies-usage-table](https://user-images.githubusercontent.com/25298055/30967199-c388ffa2-a45b-11e7-8e9c-753d2a5bce2e.png)
