### PR TITLE
GroupMembershipResolver: Prefetch related objects before resolving

### DIFF
--- a/library/Director/Objects/GroupMembershipResolver.php
+++ b/library/Director/Objects/GroupMembershipResolver.php
@@ -394,6 +394,9 @@ abstract class GroupMembershipResolver
             if ($object->isTemplate()) {
                 continue;
             }
+
+            $object->prefetchAllRelatedTypes();
+
             // TODO: fix this last hard host dependency
             $resolver = HostApplyMatches::prepare($object);
             foreach ($groups as $groupId => $filter) {


### PR DESCRIPTION
Without this resolving can be slowed down by database queries for
related objects.

---

I found this while syncing about 6700 hosts with about 1800 hostgroups present.

Director permanently queried for related objects.

The program is still burning on the sync as I post this, so potentially still WIP here. But its a large environment...