### PR TITLE
Support for per zone hostgroups.

### DIFF
--- a/application/forms/IcingaHostGroupForm.php
+++ b/application/forms/IcingaHostGroupForm.php
@@ -18,8 +18,26 @@ class IcingaHostGroupForm extends DirectorObjectForm
 
         $this->addGroupDisplayNameElement()
              ->addAssignmentElements()
+             ->addZoneElements()
              ->setButtons();
     }
+
+    protected function addZoneElements()
+    {
+        $this->addZoneElement();
+        $this->addDisplayGroup(array('zone_id'), 'clustering', array(
+            'decorators' => array(
+                'FormElements',
+                array('HtmlTag', array('tag' => 'dl')),
+                'Fieldset',
+            ),
+            'order' => 80,
+            'legend' => $this->translate('Zone settings')
+        ));
+
+        return $this;
+    }
+
 
     protected function addAssignmentElements()
     {

--- a/library/Director/Objects/IcingaHostGroup.php
+++ b/library/Director/Objects/IcingaHostGroup.php
@@ -11,8 +11,38 @@ class IcingaHostGroup extends IcingaObjectGroup
 {
     protected $table = 'icinga_hostgroup';
 
+    protected $relations = array(
+        'zone'             => 'IcingaZone',
+    );
+
+    protected $defaultProperties = array(
+        'id'            => null,
+        'object_name'   => null,
+        'object_type'   => null,
+        'disabled'      => 'n',
+        'display_name'  => null,
+        'assign_filter' => null,
+        'zone_id'       => null,
+    );
+
+    protected $propertiesNotForRendering = array(
+        'id',
+        'object_name',
+        'object_type',
+        'zone',
+    );
+
     /** @var HostGroupMembershipResolver */
     protected $hostgroupMembershipResolver;
+
+    public function getRenderingZone(IcingaConfig $config = null)
+    {
+        if ($this->getSingleResolvedProperty('zone_id')) {
+            return $config->getZoneName($this->get('zone_id'));
+        } else {
+            return $this->connection->getDefaultGlobalZoneName();
+        }
+    }
 
     public function supportsAssignments()
     {

--- a/library/Director/Objects/IcingaTimePeriodRanges.php
+++ b/library/Director/Objects/IcingaTimePeriodRanges.php
@@ -261,6 +261,9 @@ class IcingaTimePeriodRanges implements Iterator, Countable, IcingaConfigRendere
         if (empty($this->ranges) && $this->object->object_type === 'template') {
             return '';
         }
+        if (empty($this->ranges)) {
+            return '';
+        }
 
         $string = "    ranges = {\n";
 


### PR DESCRIPTION
In my setup, I have a icinga master node and several satellites that belong to different companies.
In the current implementation, all hostgroups are replicated to all satellites and our costumers know about each others hostgroups.

This patch creates a zone_id for the hostgroup and creates the hostgroups' configuration file in their specific rendering zone.

We require a mysql schema change:
```
ALTER TABLE icinga_hostgroup ADD zone_id INT(10) UNSIGNED DEFAULT NULL;

ALTER TABLE icinga_hostgroup ADD CONSTRAINT icinga_hostgroup_zone FOREIGN KEY zone (zone_id) REFERENCES icinga_zone (id) ON DELETE RESTRICT ON UPDATE CASCADE;
```

Do you think that this makes sense or can we do it in a different way? If you agree, please merge this. If you don't, please let me know how can i improve the patch so that is gets merged.

Nuno Fernandes