### PR TITLE
Bugfix/timeperiodrangeprint

### DIFF
--- a/application/forms/IcingaHostGroupForm.php
+++ b/application/forms/IcingaHostGroupForm.php
@@ -18,8 +18,26 @@ class IcingaHostGroupForm extends DirectorObjectForm
 
         $this->addGroupDisplayNameElement()
              ->addAssignmentElements()
+             ->addZoneElements()
              ->setButtons();
     }
+
+    protected function addZoneElements()
+    {
+        $this->addZoneElement();
+        $this->addDisplayGroup(array('zone_id'), 'clustering', array(
+            'decorators' => array(
+                'FormElements',
+                array('HtmlTag', array('tag' => 'dl')),
+                'Fieldset',
+            ),
+            'order' => 80,
+            'legend' => $this->translate('Zone settings')
+        ));
+
+        return $this;
+    }
+
 
     protected function addAssignmentElements()
     {

--- a/library/Director/Objects/IcingaHostGroup.php
+++ b/library/Director/Objects/IcingaHostGroup.php
@@ -11,8 +11,38 @@ class IcingaHostGroup extends IcingaObjectGroup
 {
     protected $table = 'icinga_hostgroup';
 
+    protected $relations = array(
+        'zone'             => 'IcingaZone',
+    );
+
+    protected $defaultProperties = array(
+        'id'            => null,
+        'object_name'   => null,
+        'object_type'   => null,
+        'disabled'      => 'n',
+        'display_name'  => null,
+        'assign_filter' => null,
+        'zone_id'       => null,
+    );
+
+    protected $propertiesNotForRendering = array(
+        'id',
+        'object_name',
+        'object_type',
+        'zone',
+    );
+
     /** @var HostGroupMembershipResolver */
     protected $hostgroupMembershipResolver;
+
+    public function getRenderingZone(IcingaConfig $config = null)
+    {
+        if ($this->getSingleResolvedProperty('zone_id')) {
+            return $config->getZoneName($this->get('zone_id'));
+        } else {
+            return $this->connection->getDefaultGlobalZoneName();
+        }
+    }
 
     public function supportsAssignments()
     {

--- a/library/Director/Objects/IcingaTimePeriodRanges.php
+++ b/library/Director/Objects/IcingaTimePeriodRanges.php
@@ -261,6 +261,9 @@ class IcingaTimePeriodRanges implements Iterator, Countable, IcingaConfigRendere
         if (empty($this->ranges) && $this->object->object_type === 'template') {
             return '';
         }
+        if (empty($this->ranges)) {
+            return '';
+        }
 
         $string = "    ranges = {\n";
 

--- a/schema/mysql-migrations/upgrade_146.sql
+++ b/schema/mysql-migrations/upgrade_146.sql
@@ -1,0 +1,12 @@
+ALTER TABLE icinga_hostgroup
+  ADD zone_id INT(10) UNSIGNED DEFAULT NULL;
+
+ALTER TABLE icinga_hostgroup
+  ADD CONSTRAINT icinga_hostgroup_zone
+  FOREIGN KEY zone (zone_id) REFERENCES icinga_zone (id)
+   ON DELETE RESTRICT
+   ON UPDATE CASCADE;
+
+INSERT INTO director_schema_migration
+  (schema_version, migration_time)
+  VALUES (146, NOW());

--- a/schema/mysql.sql
+++ b/schema/mysql.sql
@@ -787,9 +787,16 @@ CREATE TABLE icinga_hostgroup (
   disabled ENUM('y', 'n') NOT NULL DEFAULT 'n',
   display_name VARCHAR(255) DEFAULT NULL,
   assign_filter TEXT DEFAULT NULL,
+  zone_id int(10) unsigned DEFAULT NULL,
   PRIMARY KEY (id),
   UNIQUE INDEX object_name (object_name),
   KEY search_idx (display_name)
+  KEY icinga_hostgroup_zone (zone_id),
+  CONSTRAINT icinga_hostgroup_zone
+  FOREIGN KEY (zone_id)
+  REFERENCES icinga_zone (id)
+    ON DELETE RESTRICT
+    ON UPDATE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 -- TODO: probably useless

--- a/schema/pgsql-migrations/upgrade_145.sql
+++ b/schema/pgsql-migrations/upgrade_145.sql
@@ -1,0 +1,4 @@
+
+INSERT INTO director_schema_migration
+  (schema_version, migration_time)
+  VALUES (145, NOW());

--- a/schema/pgsql-migrations/upgrade_146.sql
+++ b/schema/pgsql-migrations/upgrade_146.sql
@@ -1,0 +1,13 @@
+ALTER TABLE icinga_hostgroup
+  ADD COLUMN zone_id integer DEFAULT NULL;
+
+ALTER TABLE icinga_hostgroup
+  ADD CONSTRAINT icinga_hostgroup_zone
+    FOREIGN KEY (zone_id)
+    REFERENCES icinga_zone (id)
+    ON DELETE RESTRICT
+    ON UPDATE CASCADE;
+
+INSERT INTO director_schema_migration
+  (schema_version, migration_time)
+  VALUES (146, NOW());

--- a/schema/pgsql.sql
+++ b/schema/pgsql.sql
@@ -973,11 +973,17 @@ CREATE TABLE icinga_hostgroup (
   disabled enum_boolean NOT NULL DEFAULT 'n',
   display_name character varying(255) DEFAULT NULL,
   assign_filter text DEFAULT NULL,
-  PRIMARY KEY (id)
+  PRIMARY KEY (id),
+  CONSTRAINT icinga_hostgroup_zone
+  FOREIGN KEY (zone_id)
+    REFERENCES icinga_zone (id)
+    ON DELETE RESTRICT
+    ON UPDATE CASCADE
 );
 
 CREATE UNIQUE INDEX hostgroup_object_name ON icinga_hostgroup (object_name);
 CREATE INDEX hostgroup_search_idx ON icinga_hostgroup (display_name);
+CREATE INDEX hostgroup_zone ON icinga_hostgroup (zone_id);
 
 
 -- -- TODO: probably useless


### PR DESCRIPTION
When i have a timeperiod without defined ranges (they are imported from the template), the director code generates a configuration like:

```
object TimePeriod "timeperiod-10x5" {
    import "legacy-timeperiod"
    import "timeperiod-template-10x5"

    display_name = "timeperiod-10x5"
    ranges = {
    }
}
```

It generates an empty ranges. This patch checks if the ranges array is empty and if so, i doesn't generate any timerange.
After patch we get:

```
object TimePeriod "timeperiod-10x5" {
    import "legacy-timeperiod"
    import "timeperiod-template-10x5"

    display_name = "timeperiod-10x5"
}
```
