### PR TITLE
fix a copy&paste error in health check documentation

### DIFF
--- a/doc/60-CLI.md
+++ b/doc/60-CLI.md
@@ -313,7 +313,7 @@ Health. This will run all or just one of the following test suites:
 
 #### Usage
 
-`icingacli director <type> clone <name> --from <original> [options]`
+`icingacli director health check [options]`
 
 #### Options
 
@@ -327,6 +327,8 @@ Health. This will run all or just one of the following test suites:
 ```shell
 icingacli director health check
 ```
+
+Example for running a check only for the configuration:
 
 ```shell
 icingacli director health check --check config


### PR DESCRIPTION
There was an copy&paste error in the health check documentation

I added another example with the short form of the check just in case we need the short form for the ITL integration.