### PR TITLE
add Zone option to Dependency Form

### DIFF
--- a/application/forms/IcingaDependencyForm.php
+++ b/application/forms/IcingaDependencyForm.php
@@ -31,7 +31,28 @@ class IcingaDependencyForm extends DirectorObjectForm
              ->addAssignmentElements()
              ->addEventFilterElements(['states'])
              ->groupMainProperties()
+             ->addZoneSection()
              ->setButtons();
+    }
+
+    protected function addZoneSection()
+    {
+        $this->addZoneElement(true);
+
+        $elements = array(
+            'zone_id',
+        );
+        $this->addDisplayGroup($elements, 'clustering', array(
+            'decorators' => array(
+                'FormElements',
+                array('HtmlTag', array('tag' => 'dl')),
+                'Fieldset',
+            ),
+            'order' => 80,
+            'legend' => $this->translate('Zone settings')
+        ));
+
+        return $this;
     }
 
     protected function addNameElement()


### PR DESCRIPTION
I'd like to propose this small change to "Dependencies", which allows users to force a Dependency into a specific zone.  This is useful when someone wants to create a dependency between an object in one zone to an object in a parent zone.  If the Dependency apply rule is defined in the global zone (current behaviour), an Endpoint in the child zone may try to apply the dependency to its object, but will throw an error because it does not know about the parent object in another zone.  Forcing the Dependency only to deploy to the parent zone fixes that problem.  