### PR TITLE
Allow to set a TimePeriod for an User via GUI

### DIFF
--- a/application/forms/IcingaUserForm.php
+++ b/application/forms/IcingaUserForm.php
@@ -44,6 +44,7 @@ class IcingaUserForm extends DirectorObjectForm
              ->addImportsElement()
              ->addDisplayNameElement()
              ->addEnableNotificationsElement()
+             ->addPeriodElement()
              ->addDisabledElement()
              ->addZoneElements()
              ->addEventFilterElements()
@@ -118,6 +119,27 @@ class IcingaUserForm extends DirectorObjectForm
             )
         ));
 
+        return $this;
+    }
+
+    protected function addPeriodElement()
+    {
+        $periods = $this->db->enumTimeperiods();
+        if (empty($periods)) {
+            return $this;
+        }
+        $this->addElement(
+            'select',
+            'period_id',
+            array(
+                'label' => $this->translate('Time period'),
+                'description' => $this->translate(
+                    'The name of a time period which determines when this'
+                    . ' notification should be triggered. Not set by default.'
+                ),
+                'multiOptions' => $this->optionalEnum($periods),
+            )
+        );
         return $this;
     }
 


### PR DESCRIPTION
With the CLI, a time period could already be assigned to a user. With this patch it is also possible via the GUI. The added code is copied from the IcingaNotificationForm.

Relates to this issue #944

![grafik](https://user-images.githubusercontent.com/13362393/36433390-ac8c74fa-165c-11e8-88bb-1d0f12110957.png)
