### PR TITLE
IcingaConfig: Remove library import from generated config

### DIFF
--- a/library/Director/IcingaConfig/IcingaConfig.php
+++ b/library/Director/IcingaConfig/IcingaConfig.php
@@ -476,13 +476,6 @@ class IcingaConfig
             ->createFileFromDb('dependency')
             ;
 
-        if (! $this->isLegacy()) {
-            $this->configFile(sprintf(
-                'zones.d/%s/commands',
-                $this->connection->getDefaultGlobalZoneName()
-            ))->prepend("library \"methods\"\n\n");
-        }
-
         PrefetchCache::forget();
         IcingaHost::clearAllPrefetchCaches();
 


### PR DESCRIPTION
This hasn't been used since Director doesn't set execution methods for commands anymore.

Code cleanup deluxe...