### PR TITLE
In service template it's possible to add a command template in the check_command field

### DIFF
--- a/application/controllers/SuggestController.php
+++ b/application/controllers/SuggestController.php
@@ -220,7 +220,7 @@ class SuggestController extends ActionController
 
     protected function suggestServiceFilterColumns()
     {
-        return $this->getFilterColumns('host.', [
+        return $this->getFilterColumns('service.', [
             $this->translate('Service properties'),
             $this->translate('Host properties'),
             $this->translate('Host Custom variables'),

--- a/application/controllers/SuggestController.php
+++ b/application/controllers/SuggestController.php
@@ -192,7 +192,10 @@ class SuggestController extends ActionController
     protected function suggestCheckcommandnames()
     {
         $db = $this->db()->getDbAdapter();
-        $query = $db->select()->from('icinga_command', 'object_name')->order('object_name');
+        $query = $db->select()
+            ->from('icinga_command', 'object_name')
+            ->where("object_type != 'template'")
+            ->order('object_name');
         return $db->fetchCol($query);
     }
 

--- a/application/forms/IcingaDependencyForm.php
+++ b/application/forms/IcingaDependencyForm.php
@@ -29,7 +29,7 @@ class IcingaDependencyForm extends DirectorObjectForm
              ->addBooleanElements()
              ->addPeriodElement()
              ->addAssignmentElements()
-             ->addEventFilterElements(array('states'))
+             ->addEventFilterElements(['states'])
              ->groupMainProperties()
              ->setButtons();
     }
@@ -67,23 +67,20 @@ class IcingaDependencyForm extends DirectorObjectForm
 
         $applyTo = $this->getSentOrObjectValue('apply_to');
 
-        if ($applyTo === 'host') {
-            $columns = IcingaHost::enumProperties($this->db, 'host.');
-        } elseif ($applyTo === 'service') {
-            // TODO: Also add host properties
-            $columns = IcingaService::enumProperties($this->db, 'service.');
-        } else {
+        if (! $applyTo) {
             return $this;
         }
 
-        $this->addAssignFilter(array(
-            'columns' => $columns,
+        $suggestionContext = ucfirst($applyTo) . 'FilterColumns';
+        $this->addAssignFilter([
+            'suggestionContext' => $suggestionContext,
             'required' => true,
             'description' => $this->translate(
                 'This allows you to configure an assignment filter. Please feel'
                 . ' free to combine as many nested operators as you want'
             )
-        ));
+        ]);
+
         return $this;
     }
 

--- a/application/forms/IcingaHostGroupForm.php
+++ b/application/forms/IcingaHostGroupForm.php
@@ -2,7 +2,6 @@
 
 namespace Icinga\Module\Director\Forms;
 
-use Icinga\Module\Director\Objects\IcingaHost;
 use Icinga\Module\Director\Web\Form\DirectorObjectForm;
 
 class IcingaHostGroupForm extends DirectorObjectForm
@@ -11,11 +10,11 @@ class IcingaHostGroupForm extends DirectorObjectForm
     {
         $this->addHidden('object_type', 'object');
 
-        $this->addElement('text', 'object_name', array(
+        $this->addElement('text', 'object_name', [
             'label'       => $this->translate('Hostgroup'),
             'required'    => true,
             'description' => $this->translate('Icinga object name for this host group')
-        ));
+        ]);
 
         $this->addGroupDisplayNameElement()
              ->addAssignmentElements()
@@ -24,14 +23,14 @@ class IcingaHostGroupForm extends DirectorObjectForm
 
     protected function addAssignmentElements()
     {
-        $this->addAssignFilter(array(
-            'columns' => IcingaHost::enumProperties($this->db, 'host.'),
+        $this->addAssignFilter([
+           'suggestionContext' => 'HostFilterColumns',
             'required' => false,
             'description' => $this->translate(
                 'This allows you to configure an assignment filter. Please feel'
                 . ' free to combine as many nested operators as you want'
             )
-        ));
+        ]);
 
         return $this;
     }

--- a/application/forms/IcingaNotificationForm.php
+++ b/application/forms/IcingaNotificationForm.php
@@ -92,23 +92,20 @@ class IcingaNotificationForm extends DirectorObjectForm
 
         $applyTo = $this->getSentOrObjectValue('apply_to');
 
-        if ($applyTo === 'host') {
-            $columns = IcingaHost::enumProperties($this->db, 'host.');
-        } elseif ($applyTo === 'service') {
-            // TODO: Also add host properties
-            $columns = IcingaService::enumProperties($this->db, 'service.');
-        } else {
+        if (! $applyTo) {
             return $this;
         }
 
-        $this->addAssignFilter(array(
-            'columns' => $columns,
+        $suggestionContext = ucfirst($applyTo) . 'FilterColumns';
+        $this->addAssignFilter([
             'required' => true,
+            'suggestionContext' => $suggestionContext,
             'description' => $this->translate(
                 'This allows you to configure an assignment filter. Please feel'
                 . ' free to combine as many nested operators as you want'
             )
-        ));
+        ]);
+
         return $this;
     }
 

--- a/application/forms/IcingaServiceGroupForm.php
+++ b/application/forms/IcingaServiceGroupForm.php
@@ -2,7 +2,6 @@
 
 namespace Icinga\Module\Director\Forms;
 
-use Icinga\Module\Director\Objects\IcingaService;
 use Icinga\Module\Director\Web\Form\DirectorObjectForm;
 
 class IcingaServiceGroupForm extends DirectorObjectForm
@@ -11,11 +10,11 @@ class IcingaServiceGroupForm extends DirectorObjectForm
     {
         $this->addHidden('object_type', 'object');
 
-        $this->addElement('text', 'object_name', array(
+        $this->addElement('text', 'object_name', [
             'label'       => $this->translate('Servicegroup'),
             'required'    => true,
             'description' => $this->translate('Icinga object name for this service group')
-        ));
+        ]);
 
         $this->addGroupDisplayNameElement()
              ->addAssignmentElements()
@@ -24,14 +23,14 @@ class IcingaServiceGroupForm extends DirectorObjectForm
 
     protected function addAssignmentElements()
     {
-        $this->addAssignFilter(array(
-            'columns' => IcingaService::enumProperties($this->db, 'service.'),
+        $this->addAssignFilter([
+            'suggestionContext' => 'ServiceFilterColumns',
             'required' => true,
             'description' => $this->translate(
                 'This allows you to configure an assignment filter. Please feel'
                 . ' free to combine as many nested operators as you want'
             )
-        ));
+        ]);
 
         return $this;
     }

--- a/application/forms/IcingaServiceSetForm.php
+++ b/application/forms/IcingaServiceSetForm.php
@@ -3,7 +3,6 @@
 namespace Icinga\Module\Director\Forms;
 
 use Icinga\Module\Director\Objects\IcingaHost;
-use Icinga\Module\Director\Objects\IcingaServiceSet;
 use Icinga\Module\Director\Web\Form\DirectorObjectForm;
 
 class IcingaServiceSetForm extends DirectorObjectForm
@@ -111,15 +110,15 @@ class IcingaServiceSetForm extends DirectorObjectForm
 
     protected function addAssignmentElements()
     {
-        $this->addAssignFilter(array(
-            'columns' => IcingaHost::enumProperties($this->db, 'host.'),
+        $this->addAssignFilter([
+            'suggestionContext' => 'HostFilterColumns',
             'description' => $this->translate(
                 'This allows you to configure an assignment filter. Please feel'
                 . ' free to combine as many nested operators as you want. You'
                 . ' might also want to skip this, define it later and/or just'
                 . ' add this set of services to single hosts'
             )
-        ));
+        ]);
 
         return $this;
     }

--- a/doc/82-Changelog.md
+++ b/doc/82-Changelog.md
@@ -14,6 +14,10 @@ before switching to a new version.
 * FIX: Caching had an influence on context-specific Custom Variable rendering
   when those variables contained macros (#1257)
 
+### Sync
+* FIX: The fix for #1223 caused a regression and broke Sync for objects without
+  a 'disabled' property (Sets, List members) (#1279)
+
 1.4.1
 -----
 ### Fixed issues

--- a/doc/82-Changelog.md
+++ b/doc/82-Changelog.md
@@ -6,11 +6,16 @@ before switching to a new version.
 
 1.4.3
 -----
+### Fixed issues
+* You can find issues and feature requests related to this release on our
+  [roadmap](https://github.com/Icinga/icingaweb2-module-director/milestone/13?closed=1)
+
 ### User Interface
 * FIX: Pagination used to be broken for some tables (#1273)
 
 ### Automation
-* FIX: Updating certain properties via API fails (#1315)
+* FIX: API calls changing only object relations and no "real" property resulted
+  in no change at all (#1315)
 
 1.4.2
 -----

--- a/doc/82-Changelog.md
+++ b/doc/82-Changelog.md
@@ -4,6 +4,14 @@
 Please make sure to always read our [Upgrading](05-Upgrading.md) documentation
 before switching to a new version.
 
+1.4.3
+-----
+### User Interface
+* FIX: Pagination used to be broken for some tables (#1273)
+
+### Automation
+* FIX: Updating certain properties via API fails (#1315)
+
 1.4.2
 -----
 ### Fixed issues

--- a/doc/82-Changelog.md
+++ b/doc/82-Changelog.md
@@ -22,6 +22,8 @@ before switching to a new version.
 ### User Interface
 * FIX: Assignment filters suggested only Host properties, you have been required
   to manually type Service property names
+* FIX: Hostgroups Dashlet has been shown to users with restricted permissions,
+  clicking it used to throw an error
 
 1.4.0
 -----

--- a/doc/82-Changelog.md
+++ b/doc/82-Changelog.md
@@ -4,6 +4,16 @@
 Please make sure to always read our [Upgrading](05-Upgrading.md) documentation
 before switching to a new version.
 
+1.4.2
+-----
+### Fixed issues
+* You can find issues and feature requests related to this release on our
+  [roadmap](https://github.com/Icinga/icingaweb2-module-director/milestone/13?closed=1)
+
+### Configuration rendering
+* FIX: Caching had an influence on context-specific Custom Variable rendering
+  when those variables contained macros (#1257)
+
 1.4.1
 -----
 ### Fixed issues

--- a/doc/82-Changelog.md
+++ b/doc/82-Changelog.md
@@ -10,10 +10,14 @@ before switching to a new version.
 * You can find issues and feature requests related to this release on our
   [roadmap](https://github.com/Icinga/icingaweb2-module-director/milestone/12?closed=1)
 
+### Automation
+* FIX: A Sync Rule with `merge` policy used to re-enable manually disabled objects,
+  even when no Sync Property `disabled` has been defined
+
 ### Large environments
-* Director tries to raise it's memory limit for certain memory-intensive tasks.
-  When granted more (but not infinite) memory however this had the effect that
-  he self-restricted himself to a lower limit. This has now been fixed.
+* FIX: Director tries to raise it's memory limit for certain memory-intensive
+  tasks. When granted more (but not infinite) memory however this had the effect
+  that he self-restricted himself to a lower limit.
 
 1.4.0
 -----

--- a/doc/82-Changelog.md
+++ b/doc/82-Changelog.md
@@ -19,6 +19,10 @@ before switching to a new version.
   tasks. When granted more (but not infinite) memory however this had the effect
   that he self-restricted himself to a lower limit.
 
+### User Interface
+* FIX: Assignment filters suggested only Host properties, you have been required
+  to manually type Service property names
+
 1.4.0
 -----
 ### New requirements

--- a/doc/82-Changelog.md
+++ b/doc/82-Changelog.md
@@ -4,6 +4,17 @@
 Please make sure to always read our [Upgrading](05-Upgrading.md) documentation
 before switching to a new version.
 
+1.4.1
+-----
+### Fixed issues
+* You can find issues and feature requests related to this release on our
+  [roadmap](https://github.com/Icinga/icingaweb2-module-director/milestone/12?closed=1)
+
+### Large environments
+* Director tries to raise it's memory limit for certain memory-intensive tasks.
+  When granted more (but not infinite) memory however this had the effect that
+  he self-restricted himself to a lower limit. This has now been fixed.
+
 1.4.0
 -----
 ### New requirements

--- a/doc/82-Changelog.md
+++ b/doc/82-Changelog.md
@@ -12,18 +12,19 @@ before switching to a new version.
 
 ### Automation
 * FIX: A Sync Rule with `merge` policy used to re-enable manually disabled objects,
-  even when no Sync Property `disabled` has been defined
+  even when no Sync Property `disabled` has been defined (#1223)
+* FIX: Fix SQL error on PostgreSQL when inspecting Template-Choice (#1242)
 
 ### Large environments
 * FIX: Director tries to raise it's memory limit for certain memory-intensive
   tasks. When granted more (but not infinite) memory however this had the effect
-  that he self-restricted himself to a lower limit.
+  that he self-restricted himself to a lower limit (#1222)
 
 ### User Interface
 * FIX: Assignment filters suggested only Host properties, you have been required
-  to manually type Service property names
+  to manually type Service property names (#1207)
 * FIX: Hostgroups Dashlet has been shown to users with restricted permissions,
-  clicking it used to throw an error
+  clicking it used to throw an error (#1237)
 
 1.4.0
 -----

--- a/library/Director/Application/MemoryLimit.php
+++ b/library/Director/Application/MemoryLimit.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Icinga\Module\Director\Application;
+
+class MemoryLimit
+{
+    public static function raiseTo($string)
+    {
+        $current = static::getBytes();
+        $desired = static::parsePhpIniByteString($string);
+        if ($current !== -1 && $current < $desired) {
+            ini_set('memory_limit', $string);
+        }
+    }
+
+    public static function getBytes()
+    {
+        return static::parsePhpIniByteString((string) ini_get('memory_limit'));
+    }
+
+    /**
+     * Return Bytes from PHP shorthand bytes notation
+     *
+     * http://www.php.net/manual/en/faq.using.php#faq.using.shorthandbytes
+     *
+     * > The available options are K (for Kilobytes), M (for Megabytes) and G
+     * > (for Gigabytes), and are all case-insensitive. Anything else assumes
+     * > bytes.
+     *
+     * @param $string
+     * @return int
+     */
+    public static function parsePhpIniByteString($string)
+    {
+        $val = trim($string);
+        $last = strtoupper(substr($val, -1, 1));
+
+        switch ($last) {
+            case 'G':
+                $val *= 1024;
+                // Intentional fall-through
+            case 'M':
+                $val *= 1024;
+                // Intentional fall-through
+            case 'K':
+                $val *= 1024;
+        }
+
+        return intval($val);
+    }
+}

--- a/library/Director/Application/MemoryLimit.php
+++ b/library/Director/Application/MemoryLimit.php
@@ -33,17 +33,19 @@ class MemoryLimit
     public static function parsePhpIniByteString($string)
     {
         $val = trim($string);
-        $last = strtoupper(substr($val, -1, 1));
 
-        switch ($last) {
-            case 'G':
-                $val *= 1024;
+        if (preg_match('/^(\d+)([KMG])$/', $val, $m)) {
+            $val = $m[1];
+            switch ($m[2]) {
+                case 'G':
+                    $val *= 1024;
                 // Intentional fall-through
-            case 'M':
-                $val *= 1024;
+                case 'M':
+                    $val *= 1024;
                 // Intentional fall-through
-            case 'K':
-                $val *= 1024;
+                case 'K':
+                    $val *= 1024;
+            }
         }
 
         return intval($val);

--- a/library/Director/Cli/Command.php
+++ b/library/Director/Cli/Command.php
@@ -3,6 +3,7 @@
 namespace Icinga\Module\Director\Cli;
 
 use Icinga\Cli\Command as CliCommand;
+use Icinga\Module\Director\Application\MemoryLimit;
 use Icinga\Module\Director\Core\CoreApi;
 use Icinga\Module\Director\Db;
 use Icinga\Module\Director\Objects\IcingaEndpoint;
@@ -82,9 +83,7 @@ class Command extends CliCommand
      */
     protected function raiseLimits()
     {
-        if ((string) ini_get('memory_limit') !== '-1') {
-            ini_set('memory_limit', '1024M');
-        }
+        MemoryLimit::raiseTo('1024M');
 
         ini_set('max_execution_time', 0);
         if (version_compare(PHP_VERSION, '7.0.0') < 0) {

--- a/library/Director/Dashboard/Dashlet/HostGroupsDashlet.php
+++ b/library/Director/Dashboard/Dashlet/HostGroupsDashlet.php
@@ -26,6 +26,6 @@ class HostGroupsDashlet extends Dashlet
 
     public function listRequiredPermissions()
     {
-        return array('director/hosts');
+        return array('director/hostgroups');
     }
 }

--- a/library/Director/Data/Db/DbObject.php
+++ b/library/Director/Data/Db/DbObject.php
@@ -459,6 +459,16 @@ abstract class DbObject
     }
 
     /**
+     * List all properties that changed since object creation
+     *
+     * @return array
+     */
+    public function listModifiedProperties()
+    {
+        return array_keys($this->modifiedProperties);
+    }
+
+    /**
      * Whether this object has been modified
      *
      * @return bool
@@ -666,6 +676,16 @@ abstract class DbObject
         }
 
         return null;
+    }
+
+    public function resetProperty($key)
+    {
+        $this->set($key, $this->getOriginalProperty($key));
+        if ($this->listModifiedProperties() === [$key]) {
+            $this->hasBeenModified = false;
+        }
+
+        return $this;
     }
 
     public function hasBeenLoadedFromDb()

--- a/library/Director/Db/Cache/PrefetchCache.php
+++ b/library/Director/Db/Cache/PrefetchCache.php
@@ -92,6 +92,7 @@ class PrefetchCache
         if (null === $checksum) {
             return $var->toConfigString($renderExpressions);
         } else {
+            $checksum .= (int) $renderExpressions;
             if (! array_key_exists($checksum, $this->renderedVars)) {
                 $this->renderedVars[$checksum] = $var->toConfigString($renderExpressions);
             }
@@ -100,6 +101,10 @@ class PrefetchCache
         }
     }
 
+    /**
+     * @param IcingaObject $object
+     * @return CustomVariableCache
+     */
     protected function varsCache(IcingaObject $object)
     {
         $key = $object->getShortTableName();

--- a/library/Director/IcingaConfig/IcingaConfig.php
+++ b/library/Director/IcingaConfig/IcingaConfig.php
@@ -9,6 +9,7 @@ use Icinga\Exception\ConfigurationError;
 use Icinga\Exception\IcingaException;
 use Icinga\Exception\NotFoundError;
 use Icinga\Exception\ProgrammingError;
+use Icinga\Module\Director\Application\MemoryLimit;
 use Icinga\Module\Director\Db\Cache\PrefetchCache;
 use Icinga\Module\Director\Db;
 use Icinga\Module\Director\Hook\ShipConfigFilesHook;
@@ -447,11 +448,7 @@ class IcingaConfig
 
         $start = microtime(true);
 
-        // Raise limits. TODO: do this in a failsafe way, and only if necessary
-        if ((string) ini_get('memory_limit') !== '-1') {
-            ini_set('memory_limit', '1024M');
-        }
-
+        MemoryLimit::raiseTo('1024M');
         ini_set('max_execution_time', 0);
         // Workaround for https://bugs.php.net/bug.php?id=68606 or similar
         ini_set('zend.enable_gc', 0);

--- a/library/Director/Import/Sync.php
+++ b/library/Director/Import/Sync.php
@@ -4,6 +4,7 @@ namespace Icinga\Module\Director\Import;
 
 use Exception;
 use Icinga\Data\Filter\Filter;
+use Icinga\Module\Director\Application\MemoryLimit;
 use Icinga\Module\Director\Data\Db\DbObject;
 use Icinga\Module\Director\Db;
 use Icinga\Module\Director\Db\Cache\PrefetchCache;
@@ -151,15 +152,11 @@ class Sync
     /**
      * Raise PHP resource limits
      *
-     * TODO: do this in a failsafe way, and only if necessary
-     *
      * @return self;
      */
     protected function raiseLimits()
     {
-        if ((string) ini_get('memory_limit') !== '-1') {
-            ini_set('memory_limit', '1024M');
-        }
+        MemoryLimit::raiseTo('1024M');
         ini_set('max_execution_time', 0);
 
         return $this;

--- a/library/Director/Import/Sync.php
+++ b/library/Director/Import/Sync.php
@@ -594,6 +594,7 @@ class Sync
             }
         }
 
+        /** @var DbObject|IcingaObject $object */
         foreach ($newObjects as $key => $object) {
             if (array_key_exists($key, $this->objects)) {
                 switch ($this->rule->get('update_policy')) {
@@ -605,7 +606,7 @@ class Sync
                         // TODO: re-evaluate merge settings. vars.x instead of
                         //       just "vars" might suffice.
                         $this->objects[$key]->merge($object, $this->replaceVars);
-                        if (! $hasDisabled) {
+                        if (! $hasDisabled && $object->hasProperty('disabled')) {
                             $this->objects[$key]->resetProperty('disabled');
                         }
                         break;

--- a/library/Director/Objects/IcingaObject.php
+++ b/library/Director/Objects/IcingaObject.php
@@ -512,7 +512,15 @@ abstract class IcingaObject extends DbObject implements IcingaConfigRenderer
         if (parent::hasBeenModified()) {
             return true;
         }
-        $this->resolveUnresolvedRelatedProperties();
+
+        if ($this->hasUnresolvedRelatedProperties()) {
+            $this->resolveUnresolvedRelatedProperties();
+
+            // Duplicates above code, but this makes it faster:
+            if (parent::hasBeenModified()) {
+                return true;
+            }
+        }
 
         if ($this->supportsCustomVars() && $this->vars !== null && $this->vars()->hasBeenModified()) {
             return true;
@@ -550,6 +558,11 @@ abstract class IcingaObject extends DbObject implements IcingaConfigRenderer
         }
 
         return false;
+    }
+
+    protected function hasUnresolvedRelatedProperties()
+    {
+        return ! empty($this->unresolvedRelatedProperties);
     }
 
     protected function hasUnresolvedRelatedProperty($name)

--- a/library/Director/Objects/ObjectApplyMatches.php
+++ b/library/Director/Objects/ObjectApplyMatches.php
@@ -6,6 +6,7 @@ use Icinga\Application\Benchmark;
 use Icinga\Data\Filter\Filter;
 use Icinga\Data\Filter\FilterExpression;
 use Icinga\Exception\ProgrammingError;
+use Icinga\Module\Director\Application\MemoryLimit;
 use Icinga\Module\Director\Db;
 use Icinga\Module\Director\Db\Cache\PrefetchCache;
 use stdClass;
@@ -83,11 +84,9 @@ abstract class ObjectApplyMatches
 
     protected static function raiseLimits()
     {
-        // Raise limits. TODO: do this in a failsafe way, and only if necessary
-        // Note: IcingaConfig also raises the limit for generation, **but** we need the higher limit for preview.
-        if ((string) ini_get('memory_limit') !== '-1') {
-            ini_set('memory_limit', '1024M');
-        }
+        // Note: IcingaConfig also raises the limit for generation, **but** we
+        // need the higher limit for preview.
+        MemoryLimit::raiseTo('1024M');
     }
 
     protected static function fetchFlatObjects(Db $db)

--- a/library/vendor/ipl/Data/SimpleQueryPaginationAdapter.php
+++ b/library/vendor/ipl/Data/SimpleQueryPaginationAdapter.php
@@ -56,7 +56,7 @@ class SimpleQueryPaginationAdapter implements Paginatable
 
     public function getOffset()
     {
-        return $this->query->hasOffset();
+        return $this->query->getOffset();
     }
 
     public function setOffset($offset)

--- a/module.info
+++ b/module.info
@@ -1,5 +1,5 @@
 Name: Icinga Director
-Version: 1.4.0
+Version: 1.4.1
 Depends: monitoring
 Description: Director - Config tool for Icinga 2
  Icinga Director is a configuration tool that has been designed to make

--- a/module.info
+++ b/module.info
@@ -1,5 +1,5 @@
 Name: Icinga Director
-Version: 1.4.2
+Version: 1.4.3
 Depends: monitoring
 Description: Director - Config tool for Icinga 2
  Icinga Director is a configuration tool that has been designed to make

--- a/module.info
+++ b/module.info
@@ -1,5 +1,5 @@
 Name: Icinga Director
-Version: 1.4.1
+Version: 1.4.2
 Depends: monitoring
 Description: Director - Config tool for Icinga 2
  Icinga Director is a configuration tool that has been designed to make

--- a/test/php/library/Director/Application/MemoryLimitTest.php
+++ b/test/php/library/Director/Application/MemoryLimitTest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Tests\Icinga\Module\Director\Application;
+
+use Icinga\Module\Director\Application\MemoryLimit;
+use Icinga\Module\Director\Test\BaseTestCase;
+
+class MemoryLimitTest extends BaseTestCase
+{
+    public function testBytesValuesAreHandled()
+    {
+        $this->assertTrue(is_int(MemoryLimit::parsePhpIniByteString('1073741824')));
+        $this->assertEquals(
+            1073741824,
+            MemoryLimit::parsePhpIniByteString('1073741824')
+        );
+    }
+
+    public function testIntegersAreAccepted()
+    {
+        $this->assertEquals(
+            MemoryLimit::parsePhpIniByteString(1073741824),
+            1073741824
+        );
+    }
+
+    public function testNoLimitGivesMinusOne()
+    {
+        $this->assertTrue(is_int(MemoryLimit::parsePhpIniByteString('-1')));
+        $this->assertEquals(
+            -1,
+            MemoryLimit::parsePhpIniByteString('-1')
+        );
+    }
+
+    public function testInvalidStringGivesBytes()
+    {
+        $this->assertEquals(
+            1024,
+            MemoryLimit::parsePhpIniByteString('1024MB')
+        );
+    }
+
+    public function testHandlesKiloBytes()
+    {
+        $this->assertEquals(
+            45 * 1024,
+            MemoryLimit::parsePhpIniByteString('45K')
+        );
+    }
+
+    public function testHandlesMegaBytes()
+    {
+        $this->assertEquals(
+            512 * 1024 * 1024,
+            MemoryLimit::parsePhpIniByteString('512M')
+        );
+    }
+
+    public function testHandlesGigaBytes()
+    {
+        $this->assertEquals(
+            2 * 1024 * 1024 * 1024,
+            MemoryLimit::parsePhpIniByteString('2G')
+        );
+    }
+}


### PR DESCRIPTION
In Add Service Template form you can add a 'Command Template' in 'Check command' field: the field itself shows up both commands and command templates.
![image](https://user-images.githubusercontent.com/36924916/36794739-7a6d29a6-1ca1-11e8-825c-240e97f09658.png)
Once you've created a service based on a service template with a command template as 'Check command' property, the deploy fails, throwing this error:
`critical/config: Error: Validation failed for object 'Standard Linux Server!Service with Command Template' of type 'Service'; Attribute 'check_command': Object 'Command Template' of type 'CheckCommand' does not exist.`
![image](https://user-images.githubusercontent.com/36924916/36795038-41d2bd62-1ca2-11e8-985f-c84717c09657.png)
For this reason I think that could be better to filter Command in advance and show up in 'Check command' field only real 'Command', excluding 'Command Templates' `"object_type != 'template'"`.
