### PR TITLE
IcingaArguments: allow to manage functions through API

### DIFF
--- a/library/Director/Objects/IcingaArguments.php
+++ b/library/Director/Objects/IcingaArguments.php
@@ -140,13 +140,21 @@ class IcingaArguments implements Iterator, Countable, IcingaConfigRenderer
             }
             if (property_exists($value, 'type')) {
                 if ($value->type === 'Function') {
-                    $attrs['argument_value'] = '/* Unable to fetch function body through API */';
+                    if (property_exists($value, 'body')) {
+                        $attrs['argument_value'] = $value->body;
+                    } else {
+                        $attrs['argument_value'] = '/* Unable to fetch function body through API */';
+                    }
                     $attrs['argument_format'] = 'expression';
                 }
             } elseif (property_exists($value, 'value')) {
                 if (is_object($value->value)) {
                     if ($value->value->type === 'Function') {
-                        $attrs['argument_value'] = '/* Unable to fetch function body through API */';
+                        if (property_exists($value, 'body')) {
+                            $attrs['argument_value'] = $value->value->body;
+                        } else {
+                            $attrs['argument_value'] = '/* Unable to fetch function body through API */';
+                        }
                         $attrs['argument_format'] = 'expression';
                     } else {
                         die('Unable to resolve command argument');
@@ -174,7 +182,11 @@ class IcingaArguments implements Iterator, Countable, IcingaConfigRenderer
 
         if (array_key_exists('set_if', $attrs) && is_object($attrs['set_if'])) {
             if ($attrs['set_if']->type === 'Function') {
-                $attrs['set_if'] = '/* Unable to fetch function body through API */';
+                if (property_exists($value, 'body')) {
+                    $attrs['set_if'] = $attrs['set_if']->body;
+                } else {
+                    $attrs['set_if'] = '/* Unable to fetch function body through API */';
+                }
                 $attrs['set_if_format'] = 'expression';
             }
         }


### PR DESCRIPTION
We solved our bottom-up configuration via the director API and a python script.
With this patch it is also possible to handle functions through the API

Works for us, but don't know if it breaks something else.
I don't know the reason for:
$attrs['argument_value'] = '/* Unable to fetch function body through API */';
