### PR TITLE
Update Icinga2Agent.bash

### DIFF
--- a/contrib/linux-agent-installer/Icinga2Agent.bash
+++ b/contrib/linux-agent-installer/Icinga2Agent.bash
@@ -106,7 +106,7 @@ API_ICINGA2=`cat << EOF
 object ApiListener "api" {
   cert_path = SysconfDir + "/icinga2/pki/${ICINGA2_NODENAME}.crt"
   key_path = SysconfDir + "/icinga2/pki/${ICINGA2_NODENAME}.key"
-  ca_path = SysconfDir + "/icinga2/pki/ca.crt"
+  ca_path = SysconfDir + "/icinga2/pki/trusted-master.crt"
   accept_commands = true
   accept_config = true
 }


### PR DESCRIPTION
correcting object ApiListener "api" ca_path

to be the same as created /icinga2/pki/trusted-master.crt instead of /icinga2/pki/ca.crt


makes icinga2 service not able to start due to missing file.