### PR TITLE
Improve performance of sync

### DIFF
--- a/application/controllers/SyncruleController.php
+++ b/application/controllers/SyncruleController.php
@@ -26,6 +26,9 @@ class SyncruleController extends ActionController
         $ruleName = $rule->get('rule_name');
         $this->addTitle($this->translate('Sync rule: %s'), $ruleName);
 
+        $checkForm = SyncCheckForm::load()->setSyncRule($rule)->handleRequest();
+        $runForm = SyncRunForm::load()->setSyncRule($rule)->handleRequest();
+
         if ($lastRunId = $rule->getLastSyncRunId()) {
             $run = SyncRun::load($lastRunId, $this->db());
         } else {
@@ -78,8 +81,8 @@ class SyncruleController extends ActionController
                 break;
         }
 
-        $c->add(SyncCheckForm::load()->setSyncRule($rule)->handleRequest());
-        $c->add(SyncRunForm::load()->setSyncRule($rule)->handleRequest());
+        $c->add($checkForm);
+        $c->add($runForm);
 
         if ($run) {
             $c->add(Html::h3($this->translate('Last sync run details')));

--- a/application/forms/SyncCheckForm.php
+++ b/application/forms/SyncCheckForm.php
@@ -57,7 +57,6 @@ class SyncCheckForm extends DirectorForm
             $this->setSuccessMessage(
                 $this->translate('Nothing would change, this rule is still in sync')
             );
-            parent::onSuccess();
         } else {
             $this->addError($this->translate('Checking this sync rule failed'));
         }

--- a/application/forms/SyncRunForm.php
+++ b/application/forms/SyncRunForm.php
@@ -41,7 +41,5 @@ class SyncRunForm extends DirectorForm
         } else {
             $this->addError($this->translate('Synchronization failed'));
         }
-
-        parent::onSuccess();
     }
 }

--- a/library/Director/Import/Sync.php
+++ b/library/Director/Import/Sync.php
@@ -585,9 +585,8 @@ class Sync
             return $this->objects;
         }
 
-        PrefetchCache::initialize($this->db);
-
         $this->raiseLimits()
+             ->prepareCache()
              ->startMeasurements()
              ->fetchSyncProperties()
              ->prepareRelatedImportSources()
@@ -752,5 +751,14 @@ class Sync
         }
 
         return $this->run->id;
+    }
+
+    protected function prepareCache()
+    {
+        PrefetchCache::initialize($this->db);
+
+        IcingaObject::prefetchAllRelationsByType($this->rule->object_type, $this->db);
+
+        return $this;
     }
 }

--- a/library/Director/Objects/GroupMembershipResolver.php
+++ b/library/Director/Objects/GroupMembershipResolver.php
@@ -401,7 +401,7 @@ abstract class GroupMembershipResolver
             // TODO: fix this last hard host dependency
             $resolver = HostApplyMatches::prepare($object);
             foreach ($groups as $groupId => $filter) {
-                if ($resolver->matchesFilter(Filter::fromQueryString($filter))) {
+                if ($resolver->matchesFilter($filter)) {
                     if (! array_key_exists($groupId, $mappings)) {
                         $mappings[$groupId] = array();
                     }
@@ -456,7 +456,7 @@ abstract class GroupMembershipResolver
             $list[$id] = $group->get('assign_filter');
         }
 
-        return $list;
+        return $this->parseFilters($list);
     }
 
     protected function fetchAppliedGroups()
@@ -470,7 +470,21 @@ abstract class GroupMembershipResolver
             )
         )->where('assign_filter IS NOT NULL');
 
-        return $this->db->fetchPairs($query);
+        return $this->parseFilters($this->db->fetchPairs($query));
+    }
+
+    /**
+     * Parsing a list of query strings to Filter
+     *
+     * @param string[] $list List of query strings
+     *
+     * @return Filter[]
+     */
+    protected function parseFilters($list)
+    {
+        return array_map(function ($s) {
+            return Filter::fromQueryString($s);
+        }, $list);
     }
 
     protected function fetchMissingSingleAssignments()

--- a/library/Director/Objects/ObjectApplyMatches.php
+++ b/library/Director/Objects/ObjectApplyMatches.php
@@ -25,16 +25,34 @@ abstract class ObjectApplyMatches
 
     protected static $type;
 
+    protected static $preparedFilters = array();
+
     public static function prepare(IcingaObject $object)
     {
         return new static($object);
     }
 
+    /**
+     * Prepare a Filter with fixed columns, and store the result
+     *
+     * @param Filter $filter
+     *
+     * @return Filter
+     */
+    protected static function getPreparedFilter(Filter $filter)
+    {
+        $hash = spl_object_hash($filter);
+        if (! array_key_exists($hash, self::$preparedFilters)) {
+            $filter = clone($filter);
+            static::fixFilterColumns($filter);
+            self::$preparedFilters[$hash] = $filter;
+        }
+        return self::$preparedFilters[$hash];
+    }
+
     public function matchesFilter(Filter $filter)
     {
-        $filter = clone($filter);
-        static::fixFilterColumns($filter);
-        return $filter->matches($this->flatObject);
+        return static::getPreparedFilter($filter)->matches($this->flatObject);
     }
 
     /**


### PR DESCRIPTION
This addresses multiple problems in Sync and GroupMembershipResolver.

- [x] Add Benchmark at more code locations
- [x] Sync: Prefetch related objects
- [x] GroupMembershipResolver: Parser Filter before iteration
- [x] ~~ImportRunBasedPurgeStrategy performance issue #1422 (discussed there)~~
- [x] ObjectApplyMatches: Prepare filters only once