### PR TITLE
IcingaObjectInspection: Properly read and handle config_checksum

### DIFF
--- a/library/Director/Web/Table/DbHelper.php
+++ b/library/Director/Web/Table/DbHelper.php
@@ -42,4 +42,14 @@ trait DbHelper
 
         return $value;
     }
+
+    public function getChecksum($checksum)
+    {
+        return bin2hex($this->wantBinaryValue($checksum));
+    }
+
+    public function getShortChecksum($checksum)
+    {
+        return substr($this->getChecksum($checksum), 0, 7);
+    }
 }

--- a/library/Director/Web/Table/DeploymentLogTable.php
+++ b/library/Director/Web/Table/DeploymentLogTable.php
@@ -39,11 +39,6 @@ class DeploymentLogTable extends ZfQueryBasedTable
         return $tr;
     }
 
-    protected function getShortChecksum($checksum)
-    {
-        return substr(bin2hex($this->wantBinaryValue($checksum)), 0, 7);
-    }
-
     protected function getMyRowClasses($row)
     {
         if ($row->startup_succeeded === 'y') {

--- a/library/Director/Web/Widget/IcingaObjectInspection.php
+++ b/library/Director/Web/Widget/IcingaObjectInspection.php
@@ -10,10 +10,12 @@ use dipl\Web\Widget\NameValueTable;
 use Icinga\Date\DateFormatter;
 use Icinga\Module\Director\Db;
 use Icinga\Module\Director\PlainObjectRenderer;
+use Icinga\Module\Director\Web\Table\DbHelper;
 use stdClass;
 
 class IcingaObjectInspection extends BaseElement
 {
+    use DbHelper;
     use TranslationHelper;
 
     protected $tag = 'div';
@@ -193,7 +195,7 @@ class IcingaObjectInspection extends BaseElement
             sprintf('%s:%s', $filename, $source->first_line),
             'director/config/file',
             [
-                'config_checksum'   => bin2hex($deployment->config_checksum),
+                'config_checksum'   => $this->getChecksum($deployment->config_checksum),
                 'deployment_id'     => $deployment->id,
                 'backTo'            => 'deployment',
                 'file_path'         => $filename,


### PR DESCRIPTION
This adapts behavior from DeploymentLogTable

fixes #1420