### PR TITLE
Fix settings name in PropertyModifierMakeBoolean.

### DIFF
--- a/library/Director/PropertyModifier/PropertyModifierMakeBoolean.php
+++ b/library/Director/PropertyModifier/PropertyModifierMakeBoolean.php
@@ -69,7 +69,7 @@ class PropertyModifierMakeBoolean extends PropertyModifierHook
             }
         }
 
-        switch ($this->getSetting('on_missing')) {
+        switch ($this->getSetting('on_invalid')) {
             case 'null':
                 return null;
 


### PR DESCRIPTION
This bug is also present in support/1.3 and support/1.4, but I'm not sure what the merging policy is for those. I can rebase to either of those if needed, or file separate pull requests.