### PR TITLE
PHP 7.2 compatibility: Avoid failing when attempting to render NULL column-set

### DIFF
--- a/library/vendor/ipl/Web/Table/QueryBasedTable.php
+++ b/library/vendor/ipl/Web/Table/QueryBasedTable.php
@@ -110,7 +110,8 @@ abstract class QueryBasedTable extends Table implements Countable
 
     public function renderContent()
     {
-        if (count($this->getColumnsToBeRendered())) {
+        $columns = $this->getColumnsToBeRendered();
+        if (isset($columns) && count($columns)) {
             $this->generateHeader();
         }
         $this->fetchRows();


### PR DESCRIPTION
PHP 7.2 is stricter about invoking count() with parameters which
are not countable:

 https://secure.php.net/manual/en/migration72.incompatible.php

This case is triggered in QueryBasedTable, for example when reviewing
the Activity Log:

 count(): Parameter must be an array or an object that implements Countable (QueryBasedTable.php:115)
 #0 [internal function]: Icinga\Application\ApplicationBootstrap->Icinga\Application\{closure}(2, 'count(): Parame...', '/usr/share/icin...', 115, Array)
 #1 /usr/share/icingaweb2/modules/director/library/vendor/ipl/Web/Table/QueryBasedTable.php(115): count(NULL)
 #2 /usr/share/icingaweb2/modules/director/library/vendor/ipl/Html/BaseElement.php(133): dipl\Web\Table\QueryBasedTable->renderContent()
 #3 /usr/share/icingaweb2/modules/director/library/vendor/ipl/Html/Html.php(171): dipl\Html\BaseElement->render()
 #4 /usr/share/icingaweb2/modules/director/library/vendor/ipl/Html/BaseElement.php(105): dipl\Html\Html->render()
 #5 /usr/share/icingaweb2/modules/director/library/vendor/ipl/Html/BaseElement.php(133): dipl\Html\BaseElement->renderContent()
 #6 /usr/share/icingaweb2/modules/director/library/vendor/ipl/Html/Html.php(259): dipl\Html\BaseElement->render()
 #7 /usr/share/icingaweb2/modules/director/library/vendor/ipl/Zf1/SimpleViewRenderer.php(47): dipl\Html\Html->__toString()
 #8 /usr/share/icingaweb2/modules/director/library/vendor/ipl/Zf1/SimpleViewRenderer.php(66): dipl\Zf1\SimpleViewRenderer->render()
 #9 /usr/share/icingaweb2/library/vendor/Zend/Controller/Action/HelperBroker.php(272): dipl\Zf1\SimpleViewRenderer->postDispatch()
 #10 /usr/share/icingaweb2/library/vendor/Zend/Controller/Action.php(518): Zend_Controller_Action_HelperBroker->notifyPostDispatch()
 #11 /usr/share/php/Icinga/Web/Controller/Dispatcher.php(76): Zend_Controller_Action->dispatch('activitiesActio...')
 #12 /usr/share/icingaweb2/library/vendor/Zend/Controller/Front.php(937): Icinga\Web\Controller\Dispatcher->dispatch(Object(Icinga\Web\Request), Object(Icinga\Web\Response))
 #13 /usr/share/php/Icinga/Application/Web.php(389): Zend_Controller_Front->dispatch(Object(Icinga\Web\Request), Object(Icinga\Web\Response))
 #14 /usr/share/php/Icinga/Application/webrouter.php(109): Icinga\Application\Web->dispatch()
 #15 /usr/share/icingaweb2/public/index.php(4): require_once('/usr/share/php/...')
 #16 {main}

Perhaps over-simplistically, this failure can be avoided by first
checking the countability of the relevant value with isset().