### PR TITLE
Membership cache not correctly updated in sync

### DIFF
--- a/library/Director/Db/HostMembershipHousekeeping.php
+++ b/library/Director/Db/HostMembershipHousekeeping.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Icinga\Module\Director\Db;
+
+class HostMembershipHousekeeping extends MembershipHousekeeping
+{
+    protected $type = 'host';
+}

--- a/library/Director/Db/MembershipHousekeeping.php
+++ b/library/Director/Db/MembershipHousekeeping.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace Icinga\Module\Director\Db;
+
+use Icinga\Module\Director\Application\MemoryLimit;
+use Icinga\Module\Director\Db;
+use Icinga\Module\Director\Db\Cache\PrefetchCache;
+use Icinga\Module\Director\Objects\GroupMembershipResolver;
+use Icinga\Module\Director\Objects\IcingaObject;
+use Icinga\Module\Director\Objects\IcingaObjectGroup;
+use Icinga\Module\Director\Resolver\TemplateTree;
+
+abstract class MembershipHousekeeping
+{
+    protected $type;
+
+    protected $groupType;
+
+    protected $connection;
+
+    /** @var GroupMembershipResolver */
+    protected $resolver;
+
+    /** @var IcingaObject[] */
+    protected $objects;
+
+    /** @var IcingaObjectGroup[] */
+    protected $groups;
+
+    protected $prepared = false;
+
+    public function __construct(Db $connection)
+    {
+        $this->connection = $connection;
+
+        if ($this->groupType === null) {
+            $this->groupType = $this->type . 'Group';
+        }
+    }
+
+    protected function prepare()
+    {
+        if ($this->prepared) {
+            return $this;
+        }
+
+        $this->prepareCache();
+        $this->resolver()->defer();
+
+        $this->objects = IcingaObject::loadAllByType($this->type, $this->connection);
+        $this->resolver()->addObjects($this->objects);
+
+        $this->groups = IcingaObject::loadAllByType($this->groupType, $this->connection);
+        $this->resolver()->addGroups($this->groups);
+
+        MemoryLimit::raiseTo('1024M');
+
+        $this->prepared = true;
+
+        return $this;
+    }
+
+    public function check()
+    {
+        $this->prepare();
+
+        $resolver = $this->resolver()->checkDb();
+
+        return array($resolver->getNewMappings(), $resolver->getOutdatedMappings());
+    }
+
+    public function update()
+    {
+        $this->prepare();
+
+        $this->resolver()->refreshDb(true);
+    }
+
+    protected function prepareCache()
+    {
+        PrefetchCache::initialize($this->connection);
+
+        IcingaObject::prefetchAllRelationsByType($this->type, $this->connection);
+
+        TemplateTree::setSyncMode();
+    }
+
+    protected function resolver()
+    {
+        if ($this->resolver === null) {
+            /** @var GroupMembershipResolver $class */
+            $class = 'Icinga\\Module\\Director\\Objects\\' . ucfirst($this->type) . 'GroupMembershipResolver';
+            $this->resolver = new $class($this->connection);
+        }
+
+        return $this->resolver;
+    }
+
+    /**
+     * @return IcingaObject[]
+     */
+    public function getObjects()
+    {
+        return $this->objects;
+    }
+
+    /**
+     * @return IcingaObjectGroup[]
+     */
+    public function getGroups()
+    {
+        return $this->groups;
+    }
+}

--- a/library/Director/Import/Sync.php
+++ b/library/Director/Import/Sync.php
@@ -18,6 +18,7 @@ use Icinga\Module\Director\Objects\IcingaService;
 use Icinga\Module\Director\Objects\SyncProperty;
 use Icinga\Module\Director\Objects\SyncRule;
 use Icinga\Module\Director\Objects\SyncRun;
+use Icinga\Module\Director\Resolver\TemplateTree;
 use Icinga\Module\Director\Util;
 use Icinga\Exception\IcingaException;
 
@@ -814,6 +815,8 @@ class Sync
         if ($dummy instanceof IcingaObject) {
             IcingaObject::prefetchAllRelationsByType($this->rule->object_type, $this->db);
         }
+
+        TemplateTree::setSyncMode();
 
         return $this;
     }

--- a/library/Director/Resolver/TemplateTree.php
+++ b/library/Director/Resolver/TemplateTree.php
@@ -30,6 +30,9 @@ class TemplateTree
 
     protected $templateNameToId;
 
+    /** @var bool */
+    protected static $syncMode = false;
+
     public function __construct($type, Db $connection)
     {
         $this->type = $type;
@@ -132,7 +135,8 @@ class TemplateTree
 
     public function getAncestorsFor(IcingaObject $object)
     {
-        if ($object->hasBeenModified()
+        if (static::isSyncMode()
+            || $object->hasBeenModified()
             && $object->gotImports()
             && $object->imports()->hasBeenModified()
         ) {
@@ -387,6 +391,22 @@ class TemplateTree
         // echo '<pre style="padding-top: 6em">' . $query . '</pre>';
 
         return $db->fetchAll($query);
+    }
+
+    /**
+     * @return bool
+     */
+    public static function isSyncMode()
+    {
+        return self::$syncMode;
+    }
+
+    /**
+     * @param bool $syncMode
+     */
+    public static function setSyncMode($syncMode = true)
+    {
+        self::$syncMode = $syncMode;
     }
 }
 


### PR DESCRIPTION
When object imports get changed by the sync.

The issue basically is, that the resolver is using the old imports, because `TemplateTree`
only uses the object presented when is hasn't been stored yet.

This always happens when the resolver is running deferred - after all objects have been stored.

Also I added a housekeeping CLI command to check and fix the cache:

```
$ icingacli director housekeeping memberships --apply
Checking host memberships
7825 objects - 1983 groups
Found 424 new and 56 outdated mappings
Update complete.
```