### PR TITLE
Sync: Only prefetch relations for IcingaObject

### DIFF
--- a/library/Director/Import/Sync.php
+++ b/library/Director/Import/Sync.php
@@ -816,7 +816,10 @@ class Sync
     {
         PrefetchCache::initialize($this->db);
 
-        IcingaObject::prefetchAllRelationsByType($this->rule->object_type, $this->db);
+        $dummy = IcingaObject::createByType($this->rule->object_type);
+        if ($dummy instanceof IcingaObject) {
+            IcingaObject::prefetchAllRelationsByType($this->rule->object_type, $this->db);
+        }
 
         return $this;
     }


### PR DESCRIPTION
So DatalistEntry can be synced

fixes #1048