### PR TITLE
Revert form description back to inline format

### DIFF
--- a/public/css/module.less
+++ b/public/css/module.less
@@ -888,30 +888,14 @@ form dd.active li.active input.related-action[type='submit'] {
 
 form {
   p.description {
-    color: inherit;
+    color: @gray;
     font-style: normal;
-    position: absolute;
-    bottom: 1em;
-    width: 96%;
-    max-width: unset;
-    margin-left: 13em;
-    max-height: 12em;
-    overflow-x: auto;
-    background: @tr-active-color;
-    border: 1px solid @icinga-blue;
-    border-radius: 0.5em;
-    font-size: 1.2em;
-    right: 2%;
-    color: @icinga-blue;
-    padding-left: 3em;
-    display: none;
-    z-index: 100;
+    padding: 0.5em;
   }
 
   p.description:before {
-    content: '\e881';
+    content: '\e85b';
     font-family: 'ifont';
-    font-size: 1.5em;
     color: @icinga-blue;
     position: absolute;
     margin-left: -1.5em;

--- a/public/css/module.less
+++ b/public/css/module.less
@@ -889,17 +889,18 @@ form dd.active li.active input.related-action[type='submit'] {
 form {
   p.description {
     color: @gray;
-    font-style: normal;
-    padding: 0.5em;
+    font-style: italic;
+    padding: 0.25em 0.5em;
+    display: none;
   }
 
-  p.description:before {
-    content: '\e85b';
-    font-family: 'ifont';
-    color: @icinga-blue;
-    position: absolute;
-    margin-left: -1.5em;
-    margin-top: -0.25em;
+  dd.active {
+    p.description {
+      font-style: normal;
+      display: block;
+      height: auto;
+      color: @text-color;
+    }
   }
 }
 
@@ -913,43 +914,6 @@ form.db-selector {
     margin-top: 0.5em;
     min-width: 14em;
     width: auto;
-  }
-}
-
-#layout.minimal-layout {
-  form p.description {
-    margin: 0;
-    border-radius: 0;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    max-height: 8em;
-    font-size: 0.835em;
-    max-width: unset;
-    width: auto;
-    border-left: none;
-    border-right: none;
-    border-bottom: none;
-  }
-}
-
-#layout.twocols {
-  form {
-    p.description {
-      width: 46%;
-      max-width: 46%;
-    }
-  }
-}
-
-#layout.twocols &#col1 {
-  form {
-    p.description {
-      margin-right: auto;
-      right: auto;
-      margin-left: 2%;
-      left: 0;
-    }
   }
 }
 

--- a/public/js/module.js
+++ b/public/js/module.js
@@ -612,19 +612,10 @@
             $li.addClass('active');
             $dt.addClass('active');
             $dd.addClass('active');
-            $dd.find('p.description.fading-out')
-                .stop(true)
-                .removeClass('fading-out')
-                .fadeIn('fast');
 
             $form.find('dd').not($dd)
                 .find('p.description')
-                .not('.fading-out')
-                .addClass('fading-out')
-                .delay(500)
-                .fadeOut('slow', function () {
-                    $(this).removeClass('fading-out').hide()
-                });
+                .hide();
         },
 
         highlightFormErrors: function($container)

--- a/public/js/module.js
+++ b/public/js/module.js
@@ -608,19 +608,23 @@
             var $dt = $dd.prev();
             var $form = $dd.closest('form');
 
-            var $desc = $dd.find('p.description');
-            if ($desc.length) {
-                $form.css({ marginBottom: ($desc.height() + 48) + 'px' });
-            }
-
             $form.find('dt, dd, li').removeClass('active');
             $li.addClass('active');
             $dt.addClass('active');
             $dd.addClass('active');
+            $dd.find('p.description.fading-out')
+                .stop(true)
+                .removeClass('fading-out')
+                .fadeIn('fast');
 
             $form.find('dd').not($dd)
                 .find('p.description')
-                .hide();
+                .not('.fading-out')
+                .addClass('fading-out')
+                .delay(500)
+                .fadeOut('slow', function () {
+                    $(this).removeClass('fading-out').hide()
+                });
         },
 
         highlightFormErrors: function($container)

--- a/public/js/module.js
+++ b/public/js/module.js
@@ -600,7 +600,6 @@
             }
 
             var $dd = $input.closest('dd');
-            $dd.find('p.description').show();
             if ($dd.attr('id') && $dd.attr('id').match(/button/)) {
                 return;
             }
@@ -612,10 +611,6 @@
             $li.addClass('active');
             $dt.addClass('active');
             $dd.addClass('active');
-
-            $form.find('dd').not($dd)
-                .find('p.description')
-                .hide();
         },
 
         highlightFormErrors: function($container)
@@ -636,10 +631,6 @@
             $fieldset.toggleClass('collapsed');
             this.fixFieldsetInfo($fieldset);
             this.openedFieldsets[$fieldset.attr('id')] = ! $fieldset.hasClass('collapsed');
-        },
-
-        hideInactiveFormDescriptions: function($container) {
-            $container.find('dd').not('.active').find('p.description').hide();
         },
 
         beforeRender: function(ev) {
@@ -704,7 +695,6 @@
             this.scrollHighlightIntoView($container);
             this.scrollActiveRowIntoView($container);
             this.highlightActiveDashlet($container);
-            this.hideInactiveFormDescriptions($container);
             if (iid = $container.data('activeExtensibleEntry')) {
                 $('#' + iid).focus();
                 $container.removeData('activeExtensibleEntry');


### PR DESCRIPTION
This is a partial revert from:

* 2d802128ac9629dce18d6f1bc2e2a1c308805ff7
* 73a2060b4255be0a8d443ad99290d75901f24d0c

Before:
![bildschirmfoto von 2018-06-01 15-23-42](https://user-images.githubusercontent.com/121874/40842978-ccdd36e8-65af-11e8-9810-d62e4f4a4c1f.png)

After:
![bildschirmfoto von 2018-06-01 15-23-13](https://user-images.githubusercontent.com/121874/40842958-bd9ec19c-65af-11e8-819d-6115f8eab37a.png)

Todos:
- [x] Revert style to inline
- [x] Revert JS handling
