### PR TITLE
make call to showUsage conditional on whether request is an API request

### DIFF
--- a/application/controllers/CommandController.php
+++ b/application/controllers/CommandController.php
@@ -32,7 +32,9 @@ class CommandController extends ObjectController
      */
     public function indexAction()
     {
-        $this->showUsage();
+        if (! $this->getRequest()->isApiRequest()) {
+            $this->showUsage();
+        }
         parent::indexAction();
     }
 


### PR DESCRIPTION
I'd like to propose this quick fix for an issue that has come up when adding new commands via the API.  The operation will return with an error message tagged on that says : "message":"Uncaught Error: Call to a member function isInUse() on null in....CommandController.php"  The command is added, but this error message comes back and makes the json response invalid.

The fix just skips the "showUsage()" function call for API requests (I believe that is meant for the human interface only).

 