### PR TITLE
Add input suggestion for datalist vars

### DIFF
--- a/library/Director/Web/Form/IplElement/ExtensibleSetElement.php
+++ b/library/Director/Web/Form/IplElement/ExtensibleSetElement.php
@@ -207,10 +207,6 @@ class ExtensibleSetElement extends BaseHtmlElement
             $attrs = $element->getAttributes();
             $attrs->add('class', 'director-suggest');
             $attrs->set([
-                'autocomplete'   => 'off',
-                'autocorrect'    => 'off',
-                'autocapitalize' => 'off',
-                'spellcheck'     => 'false',
                 'data-suggestion-context' => $this->suggestionContext,
             ]);
         }

--- a/public/css/module.less
+++ b/public/css/module.less
@@ -1452,8 +1452,8 @@ li.filter-chain > select.operator {
 div.filter-expression {
     .column {
         min-width: 7em;
-        max-width: 10em;
-        width: 10em;
+        max-width: 30em;
+        width: auto;
     }
 
     .sign {

--- a/public/js/module.js
+++ b/public/js/module.js
@@ -677,6 +677,9 @@
             if (! this.containerIsAutorefreshed($container) && ! this.containerIsAutoSubmitted($container)) {
                 this.putFocusOnFirstFormElement($container);
             }
+
+            // Turn off autocomplete for all suggested fields
+            $container.find('input.director-suggest').each(this.disableAutocomplete);
         },
 
         highlightActiveDashlet: function($container)
@@ -789,6 +792,14 @@
             } else {
                 $fieldset.find('legend span.element-count').remove();
             }
+        },
+
+        disableAutocomplete: function() {
+            $(this)
+                .attr('autocomplete', 'off')
+                .attr('autocorrect', 'off')
+                .attr('autocapitalize', 'off')
+                .attr('spellcheck', 'false');
         }
     };
 

--- a/public/js/module.js
+++ b/public/js/module.js
@@ -309,6 +309,14 @@
             var $el = $suggestion.closest('ul').siblings('.director-suggest');
             var val = $suggestion.text();
 
+            // extract label and key from key
+            var re = /^(.+) \[(\w+)]$/;
+
+            var withLabel = val.match(re);
+            if (withLabel) {
+                val = withLabel[2];
+            }
+
             if (val.match(/\.$/)) {
                 $el.val(val);
                 this.getSuggestionList($el, true);


### PR DESCRIPTION
Variables that have a datalist behind should be able to list suggestions.

This PR adds the appropriate suggestion lookup for all vars that are based on a datalist.

## Simple Text fields

![bildschirmfoto von 2018-08-07 15-29-31](https://user-images.githubusercontent.com/121874/43778774-d30a9368-9a56-11e8-99d0-c4a53dad03d4.png)

## Extensible sets

![bildschirmfoto von 2018-08-07 15-29-48](https://user-images.githubusercontent.com/121874/43778773-d2eb2f64-9a56-11e8-8c4f-bb8c3b190d38.png)

ref/NC/565994