### PR TITLE
RestoreObjectForm: Fix restore of multi-key and apply

### DIFF
--- a/application/forms/RestoreObjectForm.php
+++ b/application/forms/RestoreObjectForm.php
@@ -2,7 +2,10 @@
 
 namespace Icinga\Module\Director\Forms;
 
+use Icinga\Exception\NotFoundError;
+use Icinga\Exception\NotImplementedError;
 use Icinga\Module\Director\Objects\IcingaObject;
+use Icinga\Module\Director\Objects\IcingaService;
 use Icinga\Module\Director\Web\Form\DirectorForm;
 
 class RestoreObjectForm extends DirectorForm
@@ -21,9 +24,49 @@ class RestoreObjectForm extends DirectorForm
         $name = $object->getObjectName();
         $db = $this->db;
 
-        // TODO: service -> multi-key
-        if ($object::exists($name, $db)) {
-            $existing = $object::load($name, $db)->replaceWith($object);
+        $keyParams = $object->getKeyParams();
+
+        if ($object instanceof IcingaService && $object->isApplyRule()) {
+            $query = $db->getDbAdapter()
+                ->select()
+                ->from($object->getTableName())
+                ->where('object_type = ?', 'apply')
+                ->where('object_name = ?', $name);
+
+            $rules = $object::loadAll($db, $query);
+
+            if (empty($rules)) {
+                $existing = null;
+            } elseif (count($rules) === 1) {
+                $existing = current($rules);
+            } else {
+                // TODO: offer drop down?
+                throw new NotImplementedError(
+                    "Found multiple apply rule matching name '%s', can not restore!",
+                    $name
+                );
+            }
+        } else {
+            try {
+                $existing = $object::load($keyParams, $db);
+            } catch (NotFoundError $e) {
+                $existing = null;
+            }
+        }
+
+        if ($existing !== null) {
+            $typeExisting = $existing->get('object_type');
+            $typeObject = $object->get('object_type');
+            if ($typeExisting !== $typeObject) {
+                // Not sure when that may occur
+                throw new NotImplementedError(
+                    'Found existing object has a mismatching object_type: %s != %s',
+                    $typeExisting,
+                    $typeObject
+                );
+            }
+
+            $existing->replaceWith($object);
 
             if ($existing->hasBeenModified()) {
                 $msg = $this->translate('Object has been restored');


### PR DESCRIPTION
* Apply: Now uniquely identified via name (multiple matches result in error)
* Multi-Key: Loading by Multi-Key and validating object_type

Worst case an error would be thrown, but it should not overwrite the wrong object.

Tested with:
- [x] Service Set (template + object)
- [x] Service Apply
- [ ] Service (for host or template)
- [ ] Host (object + template)
- [ ] Notification
- [ ] Simple objects like user and user group