### PR TITLE
IcingaConfig: Avoid try/except for compatibility with Icinga >= 2.6

### DIFF
--- a/library/Director/IcingaConfig/IcingaConfig.php
+++ b/library/Director/IcingaConfig/IcingaConfig.php
@@ -554,14 +554,12 @@ if (! globals[DirectorOverrideTemplate]) {
      * Seems that host is missing when used in a service object, works fine for
      * apply rules
      */
-    try {
-      if (! host) {
-        var host = get_host(host_name)
-      }
-      if (! host) {
-        globals.directorWarnOnceForServiceWithoutHost()
-      }
-    } except { globals.directorWarnOnceForServiceWithoutHost() }
+    if (! host) {
+      var host = get_host(host_name)
+    }
+    if (! host) {
+      globals.directorWarnOnceForServiceWithoutHost()
+    }
 
     if (vars) {
       vars += host.vars[DirectorOverrideVars][name]


### PR DESCRIPTION
try / except was never needed there, because get_host should never
throw an exception. It will be null then.

fixes #1610

Introduced by:
* fd372c6b6286f9d8e7fbe1c9dead719bc5127790
* bf68dbcaca0a8dc85c8427042a3012cd482ff225