### PR TITLE
Add function for cache the template tree status.

### DIFF
--- a/public/js/module.js
+++ b/public/js/module.js
@@ -33,6 +33,7 @@
             this.module.on('mousedown', '.director-suggestions li', this.clickSuggestion);
             this.module.on('dblclick', 'ul.tabs a', this.tabWantsFullscreen);
             this.module.on('change', 'form input.autosubmit, form select.autosubmit', this.setAutoSubmitted);
+            this.module.on('click', 'div.content ul.tree li span.handle', this.setTreeState);
             this.module.icinga.logger.debug('Director module initialized');
         },
 
@@ -624,6 +625,23 @@
             $container.find('dd').not('.active').find('p.description').hide();
         },
 
+        setTreeState: function(ev) {
+          var btn = ev.currentTarget;
+          var tree = jQuery(btn).parents('.tree');
+          var treeStatus = {};
+
+          treeStatus = setStatusForTreeChildren(tree, treeStatus);
+          localStorage['treeStatus'] = JSON.stringify(treeStatus);
+        },
+
+        loadTreeStatus: function(tree) {
+            var treeCached = localStorage['treeStatus'];
+            if(typeof treeCached != 'undefined') {
+                var treeStatusObj = JSON.parse(treeCached);
+                setTreeStatusFromCache(tree, treeStatusObj);
+            }
+        },
+
         beforeRender: function(ev) {
             var $container = $(ev.currentTarget);
             var id = $container.attr('id');
@@ -680,6 +698,11 @@
                 $('#' + iid).focus();
                 $container.removeData('activeExtensibleEntry');
             }
+
+            if($container.find('.content ul.tree').length !== 0) {
+                this.loadTreeStatus($container.find('.content ul.tree'));
+            }
+
             // Disabled for now
             // this.alignDetailLinks();
             if (! this.containerIsAutorefreshed($container) && ! this.containerIsAutoSubmitted($container)) {
@@ -810,6 +833,46 @@
                 .attr('spellcheck', 'false');
         }
     };
+
+    function setStatusForTreeChildren(tree, treeStatus) {
+        var children = jQuery(tree).children();
+
+        $.each(children, function(index, el) {
+            if (jQuery(el).is('li')) {
+                var liClass = '';
+                if (typeof jQuery(el).attr('class') != 'undefined') {
+                    liClass = jQuery(el).attr('class');
+                }
+                treeStatus[index] = {};
+                treeStatus[index]['li'] = liClass;
+
+                if (jQuery(el).children('ul').length > 0) {
+                    treeStatus[index]['ul'] = {};
+                    treeStatus[index]['ul'] = setStatusForTreeChildren(el, treeStatus[index]['ul']);
+                }
+            } else if (jQuery(el).is('ul')) {
+                treeStatus = setStatusForTreeChildren(el, treeStatus);
+            }
+        });
+
+        return treeStatus;
+    }
+
+    function setTreeStatusFromCache(tree, treeStatus) {
+        var children = jQuery(tree).children();
+
+        $.each(children, function(index, el) {
+            if (jQuery(el).is('li')) {
+                jQuery(el).attr('class', treeStatus[index]['li']);
+
+                if (jQuery(el).children('ul').length > 0) {
+                    setTreeStatusFromCache(el, treeStatus[index]['ul']);
+                }
+            } else if (jQuery(el).is('ul')) {
+                setTreeStatusFromCache(el, treeStatus);
+            }
+        });
+    }
 
     Icinga.availableModules.director = Director;
 


### PR DESCRIPTION
The tree you can find in host/service templates will be reloaded according to the autorefresh.
The user will loose the status of the tree while he is working on it. For example this is how the user sets the tree, while searching something through the tree entries:
![image](https://user-images.githubusercontent.com/36924916/44912454-751f0900-ad2a-11e8-8af2-b9f06c177c46.png)
After 10 sec. the autorefresh will make the page reloads like:
![image](https://user-images.githubusercontent.com/36924916/44912473-89fb9c80-ad2a-11e8-9929-a1e6e026e37a.png)
In order to avoid this annoying behavior, I created a javascript function that saves the status of the tree in cache and loads the user configuration each time the page is refreshed.