### PR TITLE
Render Icinga config helpers with safe globals access

### DIFF
--- a/library/Director/IcingaConfig/IcingaConfig.php
+++ b/library/Director/IcingaConfig/IcingaConfig.php
@@ -534,7 +534,7 @@ globals.directorWarnOnceForThresholds = function() {
         return sprintf(
             '
 const DirectorOverrideTemplate = "%s"
-if (! globals[DirectorOverrideTemplate]) {
+if (! globals.contains(DirectorOverrideTemplate)) {
   const DirectorOverrideVars = "%s"
 
   globals.directorWarnedOnceForServiceWithoutHost = false;


### PR DESCRIPTION
globals[key] works, although it wasn't documented how it
behaves in the case when this field doesn't exist.

Previously this has been a dictionary which silently returns
null if the key doesn't exist. With v2.10, globals turned
into a namespace which throws an error if not existing (which is
the correct behaviour).

In order to avoid configuration errors with 2.10, this is changed
into `contains()` which has been sitting in dictionaries since 2014.
So this patch ensures compatibility with older versions as well.