### PR TITLE
Fixes count() NULL bug for SequenceMatcher.php

### DIFF
--- a/library/vendor/php-diff/lib/Diff/SequenceMatcher.php
+++ b/library/vendor/php-diff/lib/Diff/SequenceMatcher.php
@@ -349,8 +349,8 @@ class Diff_SequenceMatcher
 			return $this->matchingBlocks;
 		}
 
-		$aLength = count($this->a);
-		$bLength = count($this->b);
+		$aLength = (isset($this->a) ? count($this->a) : 0);
+		$bLength = (isset($this->b) ? count($this->b) : 0);
 
 		$queue = array(
 			array(


### PR DESCRIPTION
PHP 7.2 is stricter about invoking count() with parameters which are not countable:

 https://secure.php.net/manual/en/migration72.incompatible.php

This case is triggered in SequenceMatcher, for example when reviewing
a initial history entry of a host template:

count(): Parameter must be an array or an object that implements Countable (SequenceMatcher.php:352)

#0 /usr/share/webapps/icingaweb2/modules/director/library/vendor/php-diff/lib/Diff/SequenceMatcher.php(352): Icinga\Application\ApplicationBootstrap->Icinga\Application\{closure}(2, 'count(): Parame...', '/usr/share/weba...', 352, Array)
#1 /usr/share/webapps/icingaweb2/modules/director/library/vendor/php-diff/lib/Diff/SequenceMatcher.php(469): Diff_SequenceMatcher->getMatchingBlocks()
#2 /usr/share/webapps/icingaweb2/modules/director/library/vendor/php-diff/lib/Diff/SequenceMatcher.php(525): Diff_SequenceMatcher->getOpCodes()
#3 /usr/share/webapps/icingaweb2/modules/director/library/vendor/php-diff/lib/Diff.php(176): Diff_SequenceMatcher->getGroupedOpcodes(5)
#4 /usr/share/webapps/icingaweb2/modules/director/library/vendor/php-diff/lib/Diff/Renderer/Html/Array.php(70): Diff->getGroupedOpcodes()
#5 /usr/share/webapps/icingaweb2/modules/director/library/vendor/php-diff/lib/Diff/Renderer/Html/SideBySide.php(55): Diff_Renderer_Html_Array->render()
#6 /usr/share/webapps/icingaweb2/modules/director/library/vendor/php-diff/lib/Diff.php(104): Diff_Renderer_Html_SideBySide->render()
#7 /usr/share/webapps/icingaweb2/modules/director/library/Director/ConfigDiff.php(62): Diff->render(Object(Diff_Renderer_Html_SideBySide))
#8 /usr/share/webapps/icingaweb2/modules/director/library/Director/ConfigDiff.php(55): Icinga\Module\Director\ConfigDiff->renderHtmlSideBySide()
#9 /usr/share/webapps/icingaweb2/modules/director/library/Director/ConfigDiff.php(47): Icinga\Module\Director\ConfigDiff->renderHtml()
#10 /usr/share/webapps/icingaweb2/modules/director/library/vendor/ipl/Html/Html.php(171): Icinga\Module\Director\ConfigDiff->render()
#11 /usr/share/webapps/icingaweb2/modules/director/library/vendor/ipl/Html/Html.php(171): dipl\Html\Html->render()
#12 /usr/share/webapps/icingaweb2/modules/director/library/vendor/ipl/Html/BaseElement.php(105): dipl\Html\Html->render()
#13 /usr/share/webapps/icingaweb2/modules/director/library/vendor/ipl/Html/BaseElement.php(133): dipl\Html\BaseElement->renderContent()
#14 /usr/share/webapps/icingaweb2/modules/director/library/vendor/ipl/Html/Html.php(259): dipl\Html\BaseElement->render()
#15 /usr/share/webapps/icingaweb2/modules/director/library/vendor/ipl/Zf1/SimpleViewRenderer.php(47): dipl\Html\Html->__toString()
#16 /usr/share/webapps/icingaweb2/modules/director/library/vendor/ipl/Zf1/SimpleViewRenderer.php(66): dipl\Zf1\SimpleViewRenderer->render()
#17 /usr/share/webapps/icingaweb2/library/vendor/Zend/Controller/Action/HelperBroker.php(272): dipl\Zf1\SimpleViewRenderer->postDispatch()
#18 /usr/share/webapps/icingaweb2/library/vendor/Zend/Controller/Action.php(518): Zend_Controller_Action_HelperBroker->notifyPostDispatch()
#19 /usr/share/webapps/icingaweb2/library/Icinga/Web/Controller/Dispatcher.php(76): Zend_Controller_Action->dispatch('activityAction')
#20 /usr/share/webapps/icingaweb2/library/vendor/Zend/Controller/Front.php(937): Icinga\Web\Controller\Dispatcher->dispatch(Object(Icinga\Web\Request), Object(Icinga\Web\Response))
#21 /usr/share/webapps/icingaweb2/library/Icinga/Application/Web.php(300): Zend_Controller_Front->dispatch(Object(Icinga\Web\Request), Object(Icinga\Web\Response))
#22 /usr/share/webapps/icingaweb2/library/Icinga/Application/webrouter.php(104): Icinga\Application\Web->dispatch()
#23 /usr/share/webapps/icingaweb2/public/index.php(4): require_once('/usr/share/weba...')
#24 {main}

I fixed this like in Icinga/icingaweb2-module-director#1458.

Signed-off-by: phreeek <root@phreeek.de>