### PR TITLE
Add URL to service template creation note

### DIFF
--- a/application/forms/IcingaAddServiceForm.php
+++ b/application/forms/IcingaAddServiceForm.php
@@ -82,7 +82,14 @@ class IcingaAddServiceForm extends DirectorObjectForm
                     $this->addError($this->translate('No service has been chosen'));
                 } else {
                     if ($this->hasPermission('director/admin')) {
-                        $html = $this->translate('Please define a Service Template first');
+                        $html = sprintf(
+                            $this->translate('Please define a %s first'),
+                            Link::create(
+                                $this->translate('Service Template'),
+                                'director/service/add',
+                                ['type' => 'template']
+                            )
+                        );
                     } else {
                         $html = $this->translate('No Service Templates have been provided yet');
                     }


### PR DESCRIPTION
This follows the same principle as with hosts where the URL
already is put into. I've found it more convenient to just
click on it and not having to navigate into the services tree :)