### PR TITLE
Added information about not importing commands issue.

### DIFF
--- a/doc/80-FAQ.md
+++ b/doc/80-FAQ.md
@@ -59,6 +59,17 @@ it could happen that the default conservative max package size of your MySQL
 server bites you. Raise `max packet size` to a reasonable value, this willi
 usually fix this issue.
 
+Commands are not imported with Kickstart
+-------------------------------
+
+If after running kickstart you can't see imported check commands, try to run kickstart process manually from CLI.
+
+```sh
+icingacli director kickstart run
+```
+See "03-Automation.md" for more information.
+
+
 Import succeeded but nothing happened
 -------------------------------------
 


### PR DESCRIPTION
I had problem that commands were not imported after kickstart in icingaweb, even after deleting endpoint and adding it again. The solution was to run kickstart manually via CLI. I thought this information will be helpful the others.