### PR TITLE
Fix typo in DeployConfigForm.php

### DIFF
--- a/application/forms/DeployConfigForm.php
+++ b/application/forms/DeployConfigForm.php
@@ -33,7 +33,7 @@ class DeployConfigForm extends DirectorForm
         if ($this->deploymentId) {
             $label = $this->translate('Re-deploy now');
         } elseif ($activities === 0) {
-            $label = $this->translate('There are no pending changes. Deploy anyways');
+            $label = $this->translate('There are no pending changes. Deploy anyway');
         } else {
             $label = sprintf(
                 $this->translate('Deploy %d pending changes'),

--- a/application/locale/de_DE/LC_MESSAGES/director.po
+++ b/application/locale/de_DE/LC_MESSAGES/director.po
@@ -5019,7 +5019,7 @@ msgid "There are no pending changes"
 msgstr "Es gibt keine anstehenden Änderungen"
 
 #: application/forms/DeployConfigForm.php:36
-msgid "There are no pending changes. Deploy anyways"
+msgid "There are no pending changes. Deploy anyway"
 msgstr "Es gibt keine anstehenden Änderungen. Dennoch ausrollen"
 
 #: library/Director/Web/Widget/ImportSourceDetails.php:58


### PR DESCRIPTION
Fix the message to use a formal tone as it is being used in a technical context.

https://www.grammarly.com/blog/is-anyways-a-word/