### PR TITLE
Add description field to command argument form

### DIFF
--- a/application/forms/IcingaCommandArgumentForm.php
+++ b/application/forms/IcingaCommandArgumentForm.php
@@ -27,6 +27,11 @@ class IcingaCommandArgumentForm extends DirectorObjectForm
             'description' => $this->translate('e.g. -H or --hostname, empty means "skip_key"')
         ));
 
+        $this->addElement('text', 'description', array(
+            'label'       => $this->translate('Description'),
+            'description' => $this->translate('Description of the argument')
+        ));
+
         $this->addElement('select', 'argument_format', array(
             'label' => $this->translate('Value type'),
             'multiOptions' => array(


### PR DESCRIPTION
This small PR adds a form field to the command argument form that allows the user to add a description to a command argument.

Everything on the API side already seems to be in place and i was able to test it successfully (adding a description to an argument makes it show up in the command preview).