### PR TITLE
Bugfix/back button from service clone

### DIFF
--- a/library/Director/Web/Controller/ObjectController.php
+++ b/library/Director/Web/Controller/ObjectController.php
@@ -486,7 +486,7 @@ abstract class ObjectController extends ActionController
                 'name'  => $this->object->getObjectName(),
                 'host'  => ($this->getAllParams())['host']
                 //wp-end IMD-40
-                //changed url of the back-link to point to the edit page related to the object
+                //changed url to point to the edit page related to the object
             ],
             ['class' => 'icon-left-big']
         ));

--- a/library/Director/Web/Controller/ObjectController.php
+++ b/library/Director/Web/Controller/ObjectController.php
@@ -480,7 +480,6 @@ abstract class ObjectController extends ActionController
     {
         $this->actions()->add(Link::create(
             $this->translate('back'),
-
             'director/' . strtolower($this->getType()) . '/edit',
             [
                 'name'  => $this->object->getObjectName(),

--- a/library/Director/Web/Controller/ObjectController.php
+++ b/library/Director/Web/Controller/ObjectController.php
@@ -480,13 +480,11 @@ abstract class ObjectController extends ActionController
     {
         $this->actions()->add(Link::create(
             $this->translate('back'),
-            //wp-start IMD-40
+
             'director/' . strtolower($this->getType()) . '/edit',
             [
                 'name'  => $this->object->getObjectName(),
                 'host'  => ($this->getAllParams())['host']
-                //wp-end IMD-40
-                //changed url to point to the edit page related to the object
             ],
             ['class' => 'icon-left-big']
         ));

--- a/library/Director/Web/Controller/ObjectController.php
+++ b/library/Director/Web/Controller/ObjectController.php
@@ -480,8 +480,14 @@ abstract class ObjectController extends ActionController
     {
         $this->actions()->add(Link::create(
             $this->translate('back'),
-            'director/' . strtolower($this->getType()),
-            ['name'  => $this->object->getObjectName()],
+            //wp-start IMD-40
+            'director/' . strtolower($this->getType()) . '/edit',
+            [
+                'name'  => $this->object->getObjectName(),
+                'host'  => ($this->getAllParams())['host']
+                //wp-end IMD-40
+                //changed url to point to the edit page related to the object
+            ],
             ['class' => 'icon-left-big']
         ));
 

--- a/library/Director/Web/Controller/ObjectController.php
+++ b/library/Director/Web/Controller/ObjectController.php
@@ -486,7 +486,7 @@ abstract class ObjectController extends ActionController
                 'name'  => $this->object->getObjectName(),
                 'host'  => ($this->getAllParams())['host']
                 //wp-end IMD-40
-                //changed url to point to the edit page related to the object
+                //changed url of the back-link to point to the edit page related to the object
             ],
             ['class' => 'icon-left-big']
         ));


### PR DESCRIPTION
### Expected Behavior
When clicking on the **back** link in the **service clone tab** the edit form for the current service object should be displayed

### Current Behavior
Clicking on the link the user is redirected to a page where this error is displayed:

![screenshot from 2019-02-05 16-07-25](https://user-images.githubusercontent.com/47357312/52282261-4e5fa100-2960-11e9-8083-05ef191cbe70.png)

### Possible Solution
Pull request offers the solution

### Steps to reproduce 
1. Go to Director
2. Go into Services
3. Select a service
4. click on Clone
5. On the tab that opens up click **back**

### My Environment
* Director Version: 1.5.1
* Icinga 2 version: 2.10.1-1
* Operating System and version: Centos 7
* PHP versions: rh-php71-php-fpm-7.1.8