### PR TITLE
fix bug regarding back link in clone form

### DIFF
--- a/library/Director/Web/Controller/ObjectController.php
+++ b/library/Director/Web/Controller/ObjectController.php
@@ -481,7 +481,10 @@ abstract class ObjectController extends ActionController
         $this->actions()->add(Link::create(
             $this->translate('back'),
             'director/' . strtolower($this->getType()),
-            ['name'  => $this->object->getObjectName()],
+            [
+                'name'  => $this->object->getObjectName(),
+                'host'  => ($this->getAllParams())['host']
+            ],
             ['class' => 'icon-left-big']
         ));
 

--- a/library/Director/Web/Controller/ObjectController.php
+++ b/library/Director/Web/Controller/ObjectController.php
@@ -478,16 +478,14 @@ abstract class ObjectController extends ActionController
 
     protected function addBackToObjectLink()
     {
+        $params = $this->getAllParams();
+        unset($params['module'], $params['action'], $params['controller']);
         $this->actions()->add(Link::create(
             $this->translate('back'),
-            'director/' . strtolower($this->getType()),
-            [
-                'name'  => $this->object->getObjectName(),
-                'host'  => ($this->getAllParams())['host']
-            ],
+            'director/' . strtolower($this->getType()) . '/edit',
+            $params,
             ['class' => 'icon-left-big']
         ));
-
         return $this;
     }
 

--- a/library/Director/Web/Controller/ObjectController.php
+++ b/library/Director/Web/Controller/ObjectController.php
@@ -478,8 +478,7 @@ abstract class ObjectController extends ActionController
 
     protected function addBackToObjectLink()
     {
-        $params = $this->getAllParams();
-        unset($params['module'], $params['action'], $params['controller']);
+        $params = $this->getRequest()->getQuery();
         $this->actions()->add(Link::create(
             $this->translate('back'),
             'director/' . strtolower($this->getType()) . '/edit',


### PR DESCRIPTION
### Expected Behavior
When clicking on the **back** link in the **service clone tab** the edit form for the current service object should be displayed

### Current Behavior
Clicking on the link the user is redirected to a page where this error is displayed:

![screenshot from 2019-02-05 16-07-25](https://user-images.githubusercontent.com/47357312/52282261-4e5fa100-2960-11e9-8083-05ef191cbe70.png)

### Possible Solution
Pull request offers the solution

### Steps to reproduce 
1. Go to Director
2. Go into Services
3. Select a service
4. click on Clone
5. On the tab that opens up click **back**

### My Environment
* Director Version: 1.5.1
* Icinga 2 version: 2.10.1-1
* Operating System and version: Centos 7
* PHP versions: rh-php71-php-fpm-7.1.8