### PR TITLE
IcingaServiceSet: Delete host sets when deleting a set

### DIFF
--- a/library/Director/Objects/IcingaServiceSet.php
+++ b/library/Director/Objects/IcingaServiceSet.php
@@ -234,6 +234,19 @@ class IcingaServiceSet extends IcingaObject implements ExportInterface
         return $object;
     }
 
+    public function beforeDelete()
+    {
+        // check if this is a template, or directly assigned to a host
+        if ($this->get('host_id') === null) {
+            // find all host sets and delete them
+            foreach ($this->fetchHostSets() as $set) {
+                $set->delete();
+            }
+        }
+
+        parent::beforeDelete();
+    }
+
     /**
      * @throws \Icinga\Exception\NotFoundError
      */


### PR DESCRIPTION
This allows service sets to be deleted, including their children sets that
are assigned to hosts.

The UI forbids deleting those sets, but we can use it like this for CLI
and purging during sync.