### PR TITLE
ConfigHelper: Ensure empty vars are not written as void to config

### DIFF
--- a/library/Director/IcingaConfig/IcingaConfigHelper.php
+++ b/library/Director/IcingaConfig/IcingaConfigHelper.php
@@ -406,6 +406,10 @@ class IcingaConfigHelper
             $parts[] = static::renderString(substr($string, $offset, $i - $offset));
         }
 
-        return implode(' + ', $parts);
+        if (! empty($parts)) {
+            return implode(' + ', $parts);
+        } else {
+            return '""';
+        }
     }
 }


### PR DESCRIPTION
In renderStringWithVariables()

This can happen when variables are stored with an empty string, for an apply rule.

Normally Director won't save empty string variables, it will delete the var instead. But when you set all vars as array via sync.

If a user would have synced this to vars, it was rendered without any quotes.

```json
{
  "a": "test",
  "b": ""
}
```

Until now:

```
    vars.b =
```

Fixed:

```
    vars.b = ""
```
