### PR TITLE
Improve ActivityLog for services and servicesets

### DIFF
--- a/library/Director/Objects/IcingaServiceSet.php
+++ b/library/Director/Objects/IcingaServiceSet.php
@@ -78,6 +78,12 @@ class IcingaServiceSet extends IcingaObject implements ExportInterface
      */
     public function getServiceObjects()
     {
+        // don't try to resolve services for unstored objects - as in getServiceObjectsForSet()
+        // also for diff in activity log
+        if ($this->get('id') === null) {
+            return [];
+        }
+
         if ($this->get('host_id')) {
             $imports = $this->imports()->getObjects();
             if (empty($imports)) {
@@ -280,6 +286,9 @@ class IcingaServiceSet extends IcingaObject implements ExportInterface
      */
     public function renderToConfig(IcingaConfig $config)
     {
+        // always print the header, so you have minimal info present
+        $file = $this->getConfigFileWithHeader($config);
+
         if ($this->get('assign_filter') === null && $this->isTemplate()) {
             return;
         }
@@ -293,7 +302,6 @@ class IcingaServiceSet extends IcingaObject implements ExportInterface
         if (empty($services)) {
             return;
         }
-        $file = $this->getConfigFileWithHeader($config);
 
         // Loop over all services belonging to this set
         // add our assign rules and then add the service to the config
@@ -350,17 +358,38 @@ class IcingaServiceSet extends IcingaObject implements ExportInterface
 
     protected function getConfigHeaderComment(IcingaConfig $config)
     {
+        $name = $this->getObjectName();
+        $assign = $this->get('assign_filter');
+
         if ($config->isLegacy()) {
-            if ($this->get('assign_filter')) {
-                $comment = "## applied Service Set '%s'\n\n";
+            if ($assign !== null) {
+                return "## applied Service Set '${name}'\n\n";
             } else {
-                $comment = "## Service Set '%s' on this host\n\n";
+                return "## Service Set '${name}' on this host\n\n";
             }
         } else {
-            $comment = "/** Service Set '%s' **/\n\n";
-        }
+            $comment = [
+                "Service Set: ${name}",
+            ];
 
-        return sprintf($comment, $this->getObjectName());
+            if (($host = $this->get('host')) !== null) {
+                $comment[] = 'on host ' . $host;
+            }
+
+            if (($description = $this->get('description')) !== null) {
+                $comment[] = '';
+                foreach (preg_split('~\\n~', $description) as $line) {
+                    $comment[] = $line;
+                }
+            }
+
+            if ($assign !== null) {
+                $comment[] = '';
+                $comment[] = trim($this->renderAssign_Filter());
+            }
+
+            return "/**\n * " . join("\n * ", $comment) . "\n */\n\n";
+        }
     }
 
     public function copyVarsToService(IcingaService $service)

--- a/library/Director/Web/Controller/ObjectController.php
+++ b/library/Director/Web/Controller/ObjectController.php
@@ -234,10 +234,10 @@ abstract class ObjectController extends ActionController
         $this->addTitle($this->translate('Activity Log: %s'), $name);
 
         $db = $this->db();
-        $type = $this->getType();
+        $objectTable = $this->object->getTableName();
         $table = (new ActivityLogTable($db))
             ->setLastDeployedId($db->getLastDeploymentActivityLogId())
-            ->filterObject('icinga_' . $type, $name);
+            ->filterObject($objectTable, $name);
         if ($host = $this->params->get('host')) {
             $table->filterHost($host);
         }

--- a/library/Director/Web/Widget/ActivityLogInfo.php
+++ b/library/Director/Web/Widget/ActivityLogInfo.php
@@ -417,13 +417,38 @@ class ActivityLogInfo extends HtmlDocument
         );
     }
 
+    protected function objectToConfig(IcingaObject $object)
+    {
+        if ($object instanceof IcingaService) {
+            return $this->previewService($object);
+        } else {
+            return $object->toSingleIcingaConfig();
+        }
+    }
+
+    protected function previewService(IcingaService $service)
+    {
+        if (($set = $service->get('service_set')) !== null) {
+            // simulate rendering of service in set
+            $set = IcingaServiceSet::load($set, $this->db);
+
+            $service->set('service_set_id', null);
+            if (($assign = $set->get('assign_filter')) !== null) {
+                $service->set('object_type', 'apply');
+                $service->set('assign_filter', $assign);
+            }
+        }
+
+        return $service->toSingleIcingaConfig();
+    }
+
     /**
      * @return IcingaConfig
      * @throws \Icinga\Exception\IcingaException
      */
     protected function newConfig()
     {
-        return $this->newObject()->toSingleIcingaConfig();
+        return $this->objectToConfig($this->newObject());
     }
 
     /**
@@ -432,7 +457,7 @@ class ActivityLogInfo extends HtmlDocument
      */
     protected function oldConfig()
     {
-        return $this->oldObject()->toSingleIcingaConfig();
+        return $this->objectToConfig($this->oldObject());
     }
 
     protected function getLinkToObject()

--- a/library/Director/Web/Widget/ActivityLogInfo.php
+++ b/library/Director/Web/Widget/ActivityLogInfo.php
@@ -282,6 +282,48 @@ class ActivityLogInfo extends HtmlDocument
         }
     }
 
+    protected function getActionExtraHtml()
+    {
+        $entry = $this->entry;
+
+        $info = '';
+        $host = null;
+
+        if ($entry->object_type === 'icinga_service') {
+            if (($set = $this->getEntryProperty('service_set')) !== null) {
+                $info = Html::sprintf(
+                    '%s "%s"',
+                    $this->translate('on service set'),
+                    Link::create(
+                        $set,
+                        'director/serviceset',
+                        ['name' => $set],
+                        ['data-base-target' => '_next']
+                    )
+                );
+            } else {
+                $host = $this->getEntryProperty('host');
+            }
+        } elseif ($entry->object_type === 'icinga_service_set') {
+            $host = $this->getEntryProperty('host');
+        }
+
+        if ($host !== null) {
+            $info = Html::sprintf(
+                '%s "%s"',
+                $this->translate('on host'),
+                Link::create(
+                    $host,
+                    'director/host',
+                    ['name' => $host],
+                    ['data-base-target' => '_next']
+                )
+            );
+        }
+
+        return $info;
+    }
+
     /**
      * @return array
      * @deprecated No longer used?
@@ -497,10 +539,11 @@ class ActivityLogInfo extends HtmlDocument
             $table->addNameValueRow(
                 $this->translate('Action'),
                 Html::sprintf(
-                    '%s %s "%s"',
+                    '%s %s "%s" %s',
                     $entry->action_name,
                     $entry->object_type,
-                    $this->getLinkToObject()
+                    $this->getLinkToObject(),
+                    $this->getActionExtraHtml()
                 )
             );
         } else {


### PR DESCRIPTION
* [x] Fix links back to service and serviceset - fixes #1377
* [x] Show diffs for services of sets - fixes #1287
* [x] Show history via Service Sets details
* [x] Show diffs for service sets that don't have an `assign_filter`
* [x] Show details in ActivityLog when Object relates to another
  - Service to Host or ServiceSet
  - Set to Host