### PR TITLE
Specify command endpoint on service template

### DIFF
--- a/doc/02-Installation.md
+++ b/doc/02-Installation.md
@@ -84,7 +84,7 @@ You might want to use a script as follows for this task:
     ICINGAWEB_MODULEPATH="/usr/share/icingaweb2/modules"
     REPO_URL="https://github.com/icinga/icingaweb2-module-director"
     TARGET_DIR="${ICINGAWEB_MODULEPATH}/director"
-    MODULE_VERSION="1.6.0"
+    MODULE_VERSION="1.6.2"
     URL="${REPO_URL}/archive/v${MODULE_VERSION}.tar.gz"
     install -d -m 0755 "${TARGET_DIR}"
     wget -q -O - "$URL" | tar xfz - -C "${TARGET_DIR}" --strip-components 1
@@ -101,7 +101,7 @@ It will be immediately ready for use:
     ICINGAWEB_MODULEPATH="/usr/share/icingaweb2/modules"
     REPO_URL="https://github.com/icinga/icingaweb2-module-director"
     TARGET_DIR="${ICINGAWEB_MODULEPATH}/director"
-    MODULE_VERSION="1.6.0"
+    MODULE_VERSION="1.6.2"
     git clone "${REPO_URL}" "${TARGET_DIR}" --branch v${MODULE_VERSION}
 
 You can now directly use our current GIT master or check out a specific version.


### PR DESCRIPTION
Gives you the option to specify command endpoint on a service template. Uses drop down list of all defined endpoints in director table.

Storing configuration sets the command_endpoint_id in director.icinga_service