### PR TITLE
Avoid caching between multiple runs of sync

### DIFF
--- a/library/Director/Db/Cache/PrefetchCache.php
+++ b/library/Director/Db/Cache/PrefetchCache.php
@@ -3,6 +3,7 @@
 namespace Icinga\Module\Director\Db\Cache;
 
 use Icinga\Module\Director\CustomVariable\CustomVariable;
+use Icinga\Module\Director\Data\Db\DbObject;
 use Icinga\Module\Director\Db;
 use Icinga\Module\Director\Objects\IcingaObject;
 use Icinga\Module\Director\Resolver\HostServiceBlacklist;
@@ -36,6 +37,7 @@ class PrefetchCache
 
     public static function initialize(Db $db)
     {
+        self::forget();
         self::$instance = new static($db);
     }
 
@@ -60,6 +62,7 @@ class PrefetchCache
 
     public static function forget()
     {
+        DbObject::clearAllPrefetchCaches();
         self::$instance = null;
     }
 

--- a/library/Director/Import/Sync.php
+++ b/library/Director/Import/Sync.php
@@ -19,6 +19,7 @@ use Icinga\Module\Director\Objects\SyncProperty;
 use Icinga\Module\Director\Objects\SyncRule;
 use Icinga\Module\Director\Objects\SyncRun;
 use Icinga\Exception\IcingaException;
+use Icinga\Module\Director\Repository\IcingaTemplateRepository;
 use InvalidArgumentException;
 
 class Sync
@@ -811,6 +812,8 @@ class Sync
     protected function prepareCache()
     {
         PrefetchCache::initialize($this->db);
+        IcingaTemplateRepository::clear();
+
         $ruleObjectType = $this->rule->get('object_type');
 
         $dummy = IcingaObject::createByType($ruleObjectType);


### PR DESCRIPTION
This can happen when using SyncJob with all jobs, or when triggering syncs within the same PHP instance.

We try to reset prefetch cache, but do not purge all of it.

This can cause strange issues on object changes and deletions, that don't appear when handling a single sync.