### PR TITLE
Ensure MySQL data supports timezones

### DIFF
--- a/library/Director/Db/Migrations.php
+++ b/library/Director/Db/Migrations.php
@@ -89,6 +89,9 @@ class Migrations
      */
     public function applyPendingMigrations()
     {
+        // Ensure we have enough time to migrate
+        ini_set('max_execution_time', 0);
+
         foreach ($this->getPendingMigrations() as $migration) {
             $migration->apply($this->connection);
         }

--- a/schema/mysql-migrations/upgrade_163.sql
+++ b/schema/mysql-migrations/upgrade_163.sql
@@ -1,0 +1,36 @@
+-- when applying manually make sure to set a sensible timezone for your users
+-- otherwise the server / client timezone will be used!
+
+-- SET time_zone = '+02:00';
+
+ALTER TABLE director_activity_log
+  MODIFY change_time TIMESTAMP NOT NULL;
+
+ALTER TABLE director_deployment_log
+  MODIFY start_time TIMESTAMP NOT NULL,
+  MODIFY end_time TIMESTAMP NULL DEFAULT NULL,
+  MODIFY abort_time TIMESTAMP NULL DEFAULT NULL;
+
+ALTER TABLE director_schema_migration
+  MODIFY migration_time TIMESTAMP NOT NULL;
+
+ALTER TABLE director_job
+  MODIFY ts_last_attempt TIMESTAMP NULL DEFAULT NULL,
+  MODIFY ts_last_error TIMESTAMP NULL DEFAULT NULL;
+
+ALTER TABLE import_source
+  MODIFY last_attempt TIMESTAMP NULL DEFAULT NULL;
+
+ALTER TABLE import_run
+  MODIFY start_time TIMESTAMP NOT NULL,
+  MODIFY end_time TIMESTAMP NULL DEFAULT NULL;
+
+ALTER TABLE sync_rule
+  MODIFY last_attempt TIMESTAMP NULL DEFAULT NULL;
+
+ALTER TABLE sync_run
+  MODIFY start_time TIMESTAMP NOT NULL;
+
+INSERT INTO director_schema_migration
+  (schema_version, migration_time)
+  VALUES (163, NOW());

--- a/schema/mysql.sql
+++ b/schema/mysql.sql
@@ -17,7 +17,7 @@ CREATE TABLE director_activity_log (
   old_properties TEXT DEFAULT NULL COMMENT 'Property hash, JSON',
   new_properties TEXT DEFAULT NULL COMMENT 'Property hash, JSON',
   author VARCHAR(64) NOT NULL,
-  change_time DATETIME NOT NULL,
+  change_time TIMESTAMP NOT NULL,
   checksum VARBINARY(20) NOT NULL,
   parent_checksum VARBINARY(20) DEFAULT NULL,
   PRIMARY KEY (id),
@@ -114,9 +114,9 @@ CREATE TABLE director_deployment_log (
   config_checksum VARBINARY(20) DEFAULT NULL,
   last_activity_checksum VARBINARY(20) NOT NULL,
   peer_identity VARCHAR(64) NOT NULL,
-  start_time DATETIME NOT NULL,
-  end_time DATETIME DEFAULT NULL,
-  abort_time DATETIME DEFAULT NULL,
+  start_time TIMESTAMP NOT NULL,
+  end_time TIMESTAMP NULL DEFAULT NULL,
+  abort_time TIMESTAMP NULL DEFAULT NULL,
   duration_connection INT(10) UNSIGNED DEFAULT NULL
     COMMENT 'The time it took to connect to an Icinga node (ms)',
   duration_dump INT(10) UNSIGNED DEFAULT NULL
@@ -184,7 +184,7 @@ CREATE TABLE director_datafield_setting (
 
 CREATE TABLE director_schema_migration (
   schema_version SMALLINT UNSIGNED NOT NULL,
-  migration_time DATETIME NOT NULL,
+  migration_time TIMESTAMP NOT NULL,
   PRIMARY KEY(schema_version)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
@@ -288,8 +288,8 @@ CREATE TABLE director_job (
   run_interval INT(10) UNSIGNED NOT NULL, -- seconds
   timeperiod_id INT(10) UNSIGNED DEFAULT NULL,
   last_attempt_succeeded ENUM('y', 'n') DEFAULT NULL,
-  ts_last_attempt DATETIME DEFAULT NULL,
-  ts_last_error DATETIME DEFAULT NULL,
+  ts_last_attempt TIMESTAMP NULL DEFAULT NULL,
+  ts_last_error TIMESTAMP NULL DEFAULT NULL,
   last_error_message TEXT DEFAULT NULL,
   PRIMARY KEY (id),
   UNIQUE KEY (job_name),
@@ -1349,7 +1349,7 @@ CREATE TABLE import_source (
     'failing'
   ) NOT NULL DEFAULT 'unknown',
   last_error_message TEXT DEFAULT NULL,
-  last_attempt DATETIME DEFAULT NULL,
+  last_attempt TIMESTAMP NULL DEFAULT NULL,
   description TEXT DEFAULT NULL,
   PRIMARY KEY (id),
   UNIQUE INDEX source_name (source_name),
@@ -1406,8 +1406,8 @@ CREATE TABLE import_run (
   id INT(10) UNSIGNED AUTO_INCREMENT NOT NULL,
   source_id INT(10) UNSIGNED NOT NULL,
   rowset_checksum VARBINARY(20) DEFAULT NULL,
-  start_time DATETIME NOT NULL,
-  end_time DATETIME DEFAULT NULL,
+  start_time TIMESTAMP NOT NULL,
+  end_time TIMESTAMP NULL DEFAULT NULL,
   succeeded ENUM('y', 'n') DEFAULT NULL,
   PRIMARY KEY (id),
   CONSTRAINT import_run_source
@@ -1496,7 +1496,7 @@ CREATE TABLE sync_rule (
     'failing'
   ) NOT NULL DEFAULT 'unknown',
   last_error_message TEXT DEFAULT NULL,
-  last_attempt DATETIME DEFAULT NULL,
+  last_attempt TIMESTAMP NULL DEFAULT NULL,
   description TEXT DEFAULT NULL,
   PRIMARY KEY (id),
   UNIQUE INDEX rule_name (rule_name)
@@ -1528,7 +1528,7 @@ CREATE TABLE sync_run (
   id BIGINT(10) UNSIGNED AUTO_INCREMENT NOT NULL,
   rule_id INT(10) UNSIGNED DEFAULT NULL,
   rule_name VARCHAR(255) NOT NULL,
-  start_time DATETIME NOT NULL,
+  start_time TIMESTAMP NOT NULL,
   duration_ms INT(10) UNSIGNED DEFAULT NULL,
   objects_deleted INT(10) UNSIGNED DEFAULT 0,
   objects_created INT(10) UNSIGNED DEFAULT 0,
@@ -1844,4 +1844,4 @@ CREATE TABLE icinga_scheduled_downtime_range (
 
 INSERT INTO director_schema_migration
   (schema_version, migration_time)
-  VALUES (162, NOW());
+  VALUES (163, NOW());


### PR DESCRIPTION
This migrates all DATETIME to TIMESTAMP in MySQL, so we support timezones and every timestamp can be correctly converted between UTC (storage) and local timezone of the user.

**Only affects MySQL**

- [x] Offer DB migration
- [x] Test performance against large DB
- [x] Disable `max_execution_time` for migrations
- [x] Add note here how to apply manually

Affects the following tables:

* director_activity_log (largest update set)
* director_deployment_log
* director_schema_migration
* director_job
* import_source
* sync_rule
* sync_run

fixes #1332 
fixes #1813

## Manual installation

This fix will be released with 1.7.0 and not backported to an earlier version.

If you currently experience problems with timezones, you can apply the schema migration manually like this:

**Make a mysqldump backup before starting with the changes***

```
$ mysql icinga_director

// Set your preferred timezone if you like (important for converting from local to UTC)
// By default: client system timezone
mysql> SET time_zone = '+02:00'; -- for CEST
```

After this apply the `ALTER TABLE` statements manually:

```sql
ALTER TABLE director_activity_log
  MODIFY change_time TIMESTAMP NOT NULL;

ALTER TABLE director_deployment_log
  MODIFY start_time TIMESTAMP NOT NULL,
  MODIFY end_time TIMESTAMP NULL DEFAULT NULL,
  MODIFY abort_time TIMESTAMP NULL DEFAULT NULL;

ALTER TABLE director_schema_migration
  MODIFY migration_time TIMESTAMP NOT NULL;

ALTER TABLE director_job
  MODIFY ts_last_attempt TIMESTAMP NULL DEFAULT NULL,
  MODIFY ts_last_error TIMESTAMP NULL DEFAULT NULL;

ALTER TABLE import_source
  MODIFY last_attempt TIMESTAMP NULL DEFAULT NULL;

ALTER TABLE import_run
  MODIFY start_time TIMESTAMP NOT NULL,
  MODIFY end_time TIMESTAMP NULL DEFAULT NULL;

ALTER TABLE sync_rule
  MODIFY last_attempt TIMESTAMP NULL DEFAULT NULL;

ALTER TABLE sync_run
  MODIFY start_time TIMESTAMP NOT NULL;
```

Depending on your database size, this can take up to a few minutes.

**WARNING:** Do **not** change anything in the `director_schema_migration` table.

When you upgrade to >= 1.7 at a later date the normal schema migration will be run again, but since the table columns are already in the correct format, it won't change anything and should not fail.