### PR TITLE
IcingaConfig: Deprecate magic_apply_for as config feature

### DIFF
--- a/application/controllers/HostController.php
+++ b/application/controllers/HostController.php
@@ -221,6 +221,7 @@ class HostController extends ObjectController
             $content->add($table);
         }
 
+        /* @deprecated to be removed in 1.8.0 #1850 #1851 */
         if ($applied = $host->vars()->get($db->settings()->magic_apply_for)) {
             if ($applied instanceof CustomVariableDictionary) {
                 $table = IcingaHostAppliedForServiceTable::load($host, $applied)

--- a/library/Director/IcingaConfig/IcingaConfig.php
+++ b/library/Director/IcingaConfig/IcingaConfig.php
@@ -509,7 +509,7 @@ class IcingaConfig
             "\nconst DirectorStageDir = dirname(dirname(current_filename))\n"
             . $this->renderFlappingLogHelper()
             . $this->renderHostOverridableVars()
-            . $this->renderMagicApplyFor()
+            . $this->renderMagicApplyFor() /* @deprecated Will be removed in 1.8.0 - #1850 #1851 */
         );
 
         return $this;
@@ -575,6 +575,10 @@ if (! globals.contains(DirectorOverrideTemplate)) {
         );
     }
 
+    /**
+     * @deprecated Will be removed in 1.8.0 - #1850 #1851
+     * @return string
+     */
     protected function renderMagicApplyFor()
     {
         if (! $this->usesMagicApplyFor()) {
@@ -585,8 +589,10 @@ if (! globals.contains(DirectorOverrideTemplate)) {
 
         return sprintf(
             '
-/* Warning: this is experimental and might be removed */
+/* DEPRECATED: This feature always was experimental and will be removed in 1.8.0 (see issue #1850 #1851) */
 apply Service for (title => params in host.vars["%s"]) {
+  log(LogWarning, "config", "Director: Magic Apply For was used on Host \"" +
+    host.name + "\", it is now deprecated and will be removed in Director 1.8.0 (see issue #1850 #1851)")
 
   var override = host.vars["%s_vars"][title]
 
@@ -614,11 +620,19 @@ apply Service for (title => params in host.vars["%s"]) {
         );
     }
 
+    /**
+     * @deprecated Will be removed in 1.8.0 - #1850 #1851
+     * @return mixed|null
+     */
     protected function getMagicApplyVarName()
     {
         return $this->connection->settings()->magic_apply_for;
     }
 
+    /**
+     * @deprecated Will be removed in 1.8.0 - #1850 #1851
+     * @return string
+     */
     protected function usesMagicApplyFor()
     {
         $db = $this->db;

--- a/library/Director/Settings.php
+++ b/library/Director/Settings.php
@@ -13,7 +13,7 @@ class Settings
     protected $defaults = [
         'default_global_zone'             => 'director-global',
         'icinga_package_name'             => 'director',
-        'magic_apply_for'                 => '_director_apply_for',
+        'magic_apply_for'                 => '_director_apply_for', /* @deprecated to be removed in 1.8.0 #1850 #1851 */
         'config_format'                   => 'v2',
         'override_services_varname'       => '_override_servicevars',
         'override_services_templatename'  => 'host var overrides (Director)',


### PR DESCRIPTION
Tested with local test environment, a warning is logged in Icinga 2 when used:

```
[2019-04-30 10:36:36 +0000] warning/config: Director: Magic Apply For was used on Host "test1", it is now deprecated and will be removed in Director 1.8.0 (see issue #1850 #1851)
```

fixes #1850