### PR TITLE
add "icingacli director hostgroups" CLI command for listing hostgroups

### DIFF
--- a/application/clicommands/HostgroupsCommand.php
+++ b/application/clicommands/HostgroupsCommand.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Icinga\Module\Director\Clicommands;
+
+use Icinga\Module\Director\Cli\ObjectsCommand;
+
+/**
+ * Manage Icinga Hostgroups
+ *
+ * Use this command to list Icinga Hostgroup objects
+ */
+class HostgroupsCommand extends ObjectsCommand
+{
+}


### PR DESCRIPTION
This adds a "icingacli director hostgroups" CLI command for listing hostgroups defined in Icinga Director.