### PR TITLE
ExtensibleSet: Migrate also integers to an array

### DIFF
--- a/library/Director/Web/Form/Element/ExtensibleSet.php
+++ b/library/Director/Web/Form/Element/ExtensibleSet.php
@@ -20,7 +20,7 @@ class ExtensibleSet extends FormElement
     public function getValue()
     {
         $value = parent::getValue();
-        if (is_string($value)) {
+        if (is_string($value) || is_numeric($value)) {
             $value = [$value];
         } elseif ($value === null) {
             return $value;


### PR DESCRIPTION
In case a user switched from a plain Integer field, to a Datalist field, Extensible set failed with:

```
ExtensibleSet expects to work with Arrays X
```

ref/NC/614217