### PR TITLE
Ensure deployment logs are always collected

### DIFF
--- a/library/Director/Job/ConfigJob.php
+++ b/library/Director/Job/ConfigJob.php
@@ -8,7 +8,6 @@ use Icinga\Module\Director\IcingaConfig\IcingaConfig;
 use Icinga\Module\Director\Hook\JobHook;
 use Icinga\Module\Director\Objects\DirectorActivityLog;
 use Icinga\Module\Director\Objects\DirectorDeploymentLog;
-use Icinga\Module\Director\Util;
 use Icinga\Module\Director\Web\Form\QuickForm;
 
 class ConfigJob extends JobHook
@@ -20,6 +19,11 @@ class ConfigJob extends JobHook
     public function run()
     {
         $db = $this->db();
+
+        if (DirectorDeploymentLog::hasUncollected($db)) {
+            $this->api()->collectLogFiles($db);
+        }
+
         $this->clearLastDeployment();
 
         if ($this->shouldGenerate()) {


### PR DESCRIPTION
Especially before running health checks.

Main problem with this was that for the user in UI, logs where only collected when reloading the deployment list.

If the user doesn't wait long enough, by switching to a different controller, the deployment stays stale.

Same can happen when the ConfigJob deploys, and the deployment does not finish within 3 seconds.

@Thomas-Gelf opinion?