### PR TITLE
doc: add a note about director-global being reserved for Director

### DIFF
--- a/doc/10-How-it-works.md
+++ b/doc/10-How-it-works.md
@@ -67,6 +67,11 @@ object Zone "director-global" {
 }
 ```
 
+Please do not use this zone for your own configuration files.
+There is a zone called `global-templates` available in default Icinga
+setups that's meant for configuration files. `director-global` is reserved
+for use by Icinga Director.
+
 Zone membership handling
 ------------------------
 


### PR DESCRIPTION
We had some users using `director-global` for syncing their own configuration files. While this is technically possible it's not "best practice" and can produce some side effects. Therefore the warning.