### PR TITLE
Added thresholds for pending deployments health check

### DIFF
--- a/library/Director/Health.php
+++ b/library/Director/Health.php
@@ -36,11 +36,16 @@ class Health
         return $this;
     }
 
-    public function getCheck($name)
+    public function getCheck($name, $critical, $warning)
     {
         if (array_key_exists($name, $this->checks)) {
-            $func = $this->checks[$name];
-            $check = $this->$func();
+            if ($name === "deployment") {
+                $func = $this->checks[$name];
+                $check = $this->$func($critical, $warning);
+            } else {
+                $func = $this->checks[$name];
+                $check = $this->$func();
+            }
         } else {
             $check = new CheckResults('Invalid Parameter');
             $check->fail("There is no check named '$name'");
@@ -49,7 +54,7 @@ class Health
         return $check;
     }
 
-    public function getAllChecks()
+    public function getAllChecks($critical = 3, $warning = 2)
     {
         /** @var CheckResults[] $checks */
         $checks = [$this->checkConfig()];
@@ -58,7 +63,7 @@ class Health
             return $checks;
         }
 
-        $checks[] = $this->checkDeployments();
+        $checks[] = $this->checkDeployments($critical, $warning);
         $checks[] = $this->checkImportSources();
         $checks[] = $this->checkSyncRules();
         $checks[] = $this->checkDirectorJobs();
@@ -227,7 +232,7 @@ class Health
         return $check;
     }
 
-    public function checkDeployments()
+    public function checkDeployments($critical, $warning)
     {
         $check = new Check('Director Deployments');
 
@@ -238,17 +243,16 @@ class Health
                 "Deployment endpoint is '%s'",
                 $db->getDeploymentEndpointName()
             ));
-        })->call(function () use ($check, $db) {
+        })->call(function () use ($check, $db, $warning, $critical) {
             $count = $db->countActivitiesSinceLastDeployedConfig();
-
-            if ($count === 1) {
-                $check->succeed('There is a single un-deployed change');
-            } else {
-                $check->succeed(sprintf(
-                    'There are %d un-deployed changes',
-                    $count
-                ));
+            if ($count < $warning) {
+                $check->succeed("There is a $count un-deployed change");
+            } elseif ($count < $critical ) {
+                $check->warn("There are $count un-deployed changes");
             }
+            else {
+                $check->fail("There are a $count un-deployed change");
+          }
         });
 
         if (! DirectorDeploymentLog::hasDeployments($db)) {


### PR DESCRIPTION
Hello folks!

Since we're using autodeploy feature, we've found very uncomfortble to have thresholds hardcoded.
I've tried to add more flexibility to thresholds.
While deafult value is still 2 for warning and 3 for critical, We introduce new parameters:
- --critical_undeploy
- --warning_undeploy

Let's check it and set 2 undeployed changes via UI:
<img width="561" alt="Screenshot  о 00 28 47" src="https://user-images.githubusercontent.com/16512299/60053383-67cf7280-96e0-11e9-8a80-f455c8409100.png">

Let's check it now via CLI w/o values (use default warning = 2 and critical = 3):

```
[user@prod-mon1 director]# icingacli director health --check deployment
Director Deployments: 2 tests OK, 1x WARNING
[OK] Deployment endpoint is 'prod-mon1.com'
[WARNING] There are 2 un-deployed changes
[OK] The last Deployment was successful at 23:57
[user@prod-mon1 director]# 
```

Let's check it with some values:
```
[user@prod-mon1 director]# icingacli director health --check deployment --critical_undeploy 20 --warning_undeploy 1
Director Deployments: 2 tests OK, 1x WARNING
[OK] Deployment endpoint is 'prod-mon1.com'
[WARNING] There are 2 un-deployed changes
[OK] The last Deployment was successful at 23:57
[user@prod-mon1 director]# 

```

```
[user@prod-mon1 director]# icingacli director health --check deployment --critical_undeploy 2 --warning_undeploy 1
Director Deployments: 2 tests OK, 1x CRITICAL
[OK] Deployment endpoint is 'prod-mon1.com'
[CRITICAL] There are a 2 un-deployed change
[OK] The last Deployment was successful at 23:57
[user@prod-mon1 director]# 
```

For now, let's assume that someone got an error and set alogical **critical** < **warning**
While we can reset it to default, I've decided to swap this values:

```
[user@prod-mon1 director]# icingacli director health --check deployment --critical_undeploy 2 --warning_undeploy 100
Director Deployments: 2 tests OK, 1x WARNING
[OK] Deployment endpoint is 'prod-mon1.com'
[WARNING] There are 2 un-deployed changes
[OK] The last Deployment was successful at 23:57
[user@prod-mon1 director]# 
```

In UI it looks like this:
<img width="488" alt="Screenshot  о 00 38 44" src="https://user-images.githubusercontent.com/16512299/60053921-c2b59980-96e1-11e9-8e16-bb8442d5711e.png">

**Do not forget to modify icingacli.conf CheckCommand at /usr/share/icinga2/include/plugins-contrib.d/icingacli.conf  (centos7)**
```
object CheckCommand "icingacli-director" {
        import "icingacli"

        command += [ "director", "health", "check" ]

        arguments = {
                "--check" = {
                        value = "$icingacli_director_check$"
                        description = "Run only a specific test suite"
                }
                "--db" = {
                        value = "$icingacli_director_db$"
                        description = "Use a specific Icinga Web DB resource"
                }
                "--critical_undeploy" = {
                        value = "$director_deploy_critical$"
                        description = "Use specific value as critical for undeployed deployments"
                }
                "--warning_undeploy" = {
                        value = "$director_deploy_warning$"
                        description = "Use specific value as warning for undeployed deployments"
                }
        }
}
```