### PR TITLE
pgsql: Fix unexpected removal of current deployment

### DIFF
--- a/library/Director/Core/CoreApi.php
+++ b/library/Director/Core/CoreApi.php
@@ -687,7 +687,7 @@ constants
         $running = DirectorDeploymentLog::getRelatedToActiveStage($this, $db);
         if ($running !== null) {
             foreach ($empty as $deployment) {
-                if ($deployment->get('start_time') < $running->get('start_time')) {
+                if ($deployment->getDeploymentTimestamp() < $running->getDeploymentTimestamp()) {
                     $deployment->set('stage_collected', 'n');
                     $deployment->store();
                     $this->deleteStage($this->getPackageName(), $deployment->get('stage_name'));


### PR DESCRIPTION
The director automatically removes uncollected deployments if they're
older than the running one. Deployments are uncollected if Icinga 2 did
not write a status file or startup log (yet). This happens when you
manage to ship a deployment while Icinga 2 is already preparing to
restart with a deployed configuration. It also removes deployments
which were forgotten by Icinga 2 because of bugs in previous versions.

If there are uncollected deployments, the check whether they are older
than the running one is based on string comparison of the deployments'
start time. While this works for MySQL and MariaDB where the output of
timestamps is always ISO, it may fail for PostgreSQL because there the
output format is configurable. If the output format is set to report
the day first, the string comparison "fails" and removes every first
deployment of a month:

Deployment timestamp: 01-JUN-19 00:03:37 -07:00
Running timestamp: 31-MAY-19 23:54:53 -07:00

The string comparison now reports the deployment as older than the
running one and removes it.

The fix is as easy as to use timestamps for the comparison.