### PR TITLE
fix for issue #1142

### DIFF
--- a/library/Director/Objects/IcingaDependency.php
+++ b/library/Director/Objects/IcingaDependency.php
@@ -386,7 +386,7 @@ class IcingaDependency extends IcingaObject implements ExportInterface
         if ($class == "Icinga\Module\Director\Objects\IcingaService" ) {
             if ($name === 'parent_service_id' && $this->object_type === 'apply' ) {
                 //special case , parent service can be set as simple string for Apply
-                if ($this->properties['parent_host_id'] === null) {
+                if ($this->properties['parent_service_id'] === null) {
                     $this->reallySet(
                         'parent_service_by_name',
                         $this->unresolvedRelatedProperties[$name]


### PR DESCRIPTION
Establishing service-to-service dependencies always fails with an error message stating that the `parent_service_id` propery could not be resolved. I believe this is due to a misnamed dictionary key (probably some kind of copy&paste error?), although I admit I do not fully comprehend the inner workings of Icinga Director.