### PR TITLE
ImportedrowsTable: Order by key_column instead of 'object_name'

### DIFF
--- a/library/Director/Web/Table/ImportedrowsTable.php
+++ b/library/Director/Web/Table/ImportedrowsTable.php
@@ -87,6 +87,6 @@ class ImportedrowsTable extends SimpleQueryBasedTable
             $this->importRun->fetchRows($this->columns)
         );
 
-        return $ds->select()->order('object_name');
+        return $ds->select()->order($this->importRun->importSource()->get('key_column'));
     }
 }


### PR DESCRIPTION
fixes #1924