### PR TITLE
Fix bad looking form errors for Web 2 >= 2.7.0

### DIFF
--- a/public/css/module.less
+++ b/public/css/module.less
@@ -330,7 +330,14 @@ input[type=text], input[type=button], select, select option, textarea {
 }
 
 form ul.form-errors {
+    list-style-type: none;
     margin-bottom: 0.5em;
+    padding: 0;
+
+    ul.errors {
+      list-style-type: none;
+      padding: 0;
+    }
 
     ul.errors li {
         background: @color-critical;


### PR DESCRIPTION
Starting with Web 2.7.0 the reworked form styles are only available for
for forms with the CSS class icinga-form. Since the Director uses its
own form styles, the styles for form errors no longer apply and thus
look ugly. This commit (re)introduces those rules for the Director.

Before:

![localhost_8080_icingaweb2_config_modules (1)](https://user-images.githubusercontent.com/1894563/64115537-32a26900-cd90-11e9-907d-0004a1fd3ac4.png)

After:

![localhost_8080_icingaweb2_director_settings](https://user-images.githubusercontent.com/1894563/64115552-39c97700-cd90-11e9-99de-94736d19766c.png)
