### PR TITLE
KickstartForm: add 'UTF-8' to array of allowed charsets, to support Postgres

### DIFF
--- a/application/forms/KickstartForm.php
+++ b/application/forms/KickstartForm.php
@@ -197,7 +197,7 @@ class KickstartForm extends DirectorForm
         if ($resourceName = $this->getResourceName()) {
             $resourceConfig = ResourceFactory::getResourceConfig($resourceName);
             if (! isset($resourceConfig->charset)
-                || ! in_array($resourceConfig->charset, array('utf8', 'utf8mb4'))
+                || ! in_array($resourceConfig->charset, array('utf8', 'utf8mb4', 'UTF-8'))
             ) {
                 if ($resource = $this->getElement('resource')) {
                     $resource->addError('Please change the encoding for the director database to utf8');


### PR DESCRIPTION
After importing the sample SQL into Postgres, I get an error message saying the database needs to be set to utf8, when it already is:

![charset](https://user-images.githubusercontent.com/2446720/64153993-f148a280-cdfd-11e9-8525-2740125a51b2.png)

In my case, $resourceConfig['charset'] === 'UTF-8'. By adding this to the list of allowed charsets, the error message disappears.