### PR TITLE
Fix icinga_version to detect version without leading v/r

### DIFF
--- a/contrib/linux-agent-installer/Icinga2Agent.bash
+++ b/contrib/linux-agent-installer/Icinga2Agent.bash
@@ -109,7 +109,7 @@ redhat)
 esac
 
 icinga_version() {
-  "$ICINGA2_BIN" --version 2>/dev/null | grep -oP 'version: [rv]?\K\d+\.\d+\.\d+[^\)]*'
+  "$ICINGA2_BIN" --version 2>/dev/null | grep -oP '\(version: [rv]?\K\d+\.\d+\.\d+[^\)]*'
 }
 
 icinga_major() {


### PR DESCRIPTION
CentOS 7:
```
[root@server121 ~]# icinga2 --version 2>/dev/null | grep version
icinga2 - The Icinga 2 network monitoring daemon (version: 2.11.0-1)
License GPLv2+: GNU GPL version 2 or later <http://gnu.org/licenses/gpl2.html>
  Platform version: 7 (Core)
  Kernel version: 4.4.193-1.el7.elrepo.x86_64
```

Debian 10:
```
root@slde0030 ~ # icinga2 --version 2>/dev/null | grep version
icinga2 - The Icinga 2 network monitoring daemon (version: r2.11.0-1)
License GPLv2+: GNU GPL version 2 or later <http://gnu.org/licenses/gpl2.html>
  Platform version: 10 (buster)
  Kernel version: 4.19.0-6-amd64
```

At least for CentOS, version is not prepended by "v" or "r".