### PR TITLE
Fixing linux install script version check

### DIFF
--- a/contrib/linux-agent-installer/Icinga2Agent.bash
+++ b/contrib/linux-agent-installer/Icinga2Agent.bash
@@ -109,7 +109,7 @@ redhat)
 esac
 
 icinga_version() {
-  "$ICINGA2_BIN" --version 2>/dev/null | grep -oP '\(version: [rv]?\K\d+\.\d+\.\d+[^\)]*'
+  "$ICINGA2_BIN" --version 2>/dev/null | grep -oPi '\(version: [rv]?\K\d+\.\d+\.\d+[^\)]*'
 }
 
 version() {


### PR DESCRIPTION
It seems as if the version output of the Icinga executable changed.

The current version check searches for "version" whereas Icinga 2.1.1-1 outputs the word capitalized.

I added the `-i` flag to grep to ignore the case there instead of complicating the rexex.