### PR TITLE
ImportSource: Ensure we can create modifiers from baskets

### DIFF
--- a/library/Director/Objects/ImportSource.php
+++ b/library/Director/Objects/ImportSource.php
@@ -119,7 +119,7 @@ class ImportSource extends DbObjectWithSettings implements ExportInterface
             $this->loadedRowModifiers = $this->fetchRowModifiers();
         }
         $current = $this->loadedRowModifiers;
-        if ($current !== null && count($current) !== count($modifiers)) {
+        if (empty($current) || count($current) !== count($modifiers)) {
             $this->newRowModifiers = $modifiers;
         } else {
             $i = 0;


### PR DESCRIPTION
Before this patch the creation failed:

```
Uncaught Error: Call to a member function setProperties() on null in /usr/share/icingaweb2/modules/director/library/Director/Objects/ImportSource.php:128
Stack trace:
#0 /usr/share/icingaweb2/modules/director/library/Director/Data/Db/DbObject.php(329): Icinga\Module\Director\Objects\ImportSource->setModifiers(Array)
#1 /usr/share/icingaweb2/modules/director/library/Director/Data/Db/DbObjectWithSettings.php(23): Icinga\Module\Director\Data\Db\DbObject->set('modifiers', Array)
#2 /usr/share/icingaweb2/modules/director/library/Director/Data/Db/DbObject.php(429): Icinga\Module\Director\Data\Db\DbObjectWithSettings->set('modifiers', Array)
#3 /usr/share/icingaweb2/modules/director/library/Director/Objects/ImportSource.php(107): Icinga\Module\Director\Data\Db\DbObject->setProperties(Array)
#4 /usr/share/icingaweb2/modules/director/library/Director/DirectorObject/Automation/BasketSnapshot.php(277): Icinga\Module\Director\Objects\ImportSource::import(Object(stdClass), Object(Icinga\Module\Director\Db), true)
```