### PR TITLE
Add php-mbstring as requirement

### DIFF
--- a/doc/02-Installation.md
+++ b/doc/02-Installation.md
@@ -30,6 +30,7 @@ Requirements
 * php-pcntl (might already be built into your PHP binary)
 * php-posix (on RHEL/CentOS this is php-process, or rh-php7x-php-process)
 * php-sockets (might already be built into your PHP binary)
+* php-mbstring
 
 Database
 --------


### PR DESCRIPTION
6ca14a58b0888413a98ac0754a99524004df1c3a started using mbstring, so it needs to be specified as a requirement