### PR TITLE
Fix macros with subproperties on service-apply-rule (#2083)

### DIFF
--- a/library/Director/CustomVariable/CustomVariableString.php
+++ b/library/Director/CustomVariable/CustomVariableString.php
@@ -46,7 +46,7 @@ class CustomVariableString extends CustomVariable
     public function toConfigString($renderExpressions = false)
     {
         if ($renderExpressions) {
-            return c::renderStringWithVariables($this->getValue(), ['config']);
+            return c::renderStringWithVariables($this->getValue(), ['^config[.$]']);
         } else {
             return c::renderString($this->getValue());
         }

--- a/library/Director/IcingaConfig/IcingaConfigHelper.php
+++ b/library/Director/IcingaConfig/IcingaConfigHelper.php
@@ -385,7 +385,7 @@ class IcingaConfigHelper
                         // We got a macro
                         $macroName = substr($string, $start + 1, $i - $start - 1);
                         if (static::isValidMacroName($macroName)) {
-                            if ($whiteList === null || in_array($macroName, $whiteList)) {
+                            if ($whiteList === null || preg_match('/(' . implode(')|(', $whiteList) . ')/', $macroName)) {
                                 if ($start > $offset) {
                                     $parts[] = static::renderString(
                                         substr($string, $offset, $start - $offset)

--- a/library/Director/IcingaConfig/IcingaConfigHelper.php
+++ b/library/Director/IcingaConfig/IcingaConfigHelper.php
@@ -386,7 +386,7 @@ class IcingaConfigHelper
                         $macroName = substr($string, $start + 1, $i - $start - 1);
                         if (static::isValidMacroName($macroName)) {
                             if ($whiteList === null
-								|| preg_match('/(' . implode(')|(', $whiteList) . ')/', $macroName)
+                                || preg_match('/(' . implode(')|(', $whiteList) . ')/', $macroName)
 							) {
                                 if ($start > $offset) {
                                     $parts[] = static::renderString(

--- a/library/Director/IcingaConfig/IcingaConfigHelper.php
+++ b/library/Director/IcingaConfig/IcingaConfigHelper.php
@@ -387,7 +387,7 @@ class IcingaConfigHelper
                         if (static::isValidMacroName($macroName)) {
                             if ($whiteList === null
                                 || preg_match('/(' . implode(')|(', $whiteList) . ')/', $macroName)
-							) {
+                            ) {
                                 if ($start > $offset) {
                                     $parts[] = static::renderString(
                                         substr($string, $offset, $start - $offset)

--- a/library/Director/IcingaConfig/IcingaConfigHelper.php
+++ b/library/Director/IcingaConfig/IcingaConfigHelper.php
@@ -385,7 +385,9 @@ class IcingaConfigHelper
                         // We got a macro
                         $macroName = substr($string, $start + 1, $i - $start - 1);
                         if (static::isValidMacroName($macroName)) {
-                            if ($whiteList === null || preg_match('/(' . implode(')|(', $whiteList) . ')/', $macroName)) {
+                            if ($whiteList === null
+								|| preg_match('/(' . implode(')|(', $whiteList) . ')/', $macroName)
+							) {
                                 if ($start > $offset) {
                                     $parts[] = static::renderString(
                                         substr($string, $offset, $start - $offset)


### PR DESCRIPTION
### Fixes #2083 

In Service-Apply-Rules macros like `$config.property$` should be evaluated, currently the only macro that gets evaluated is `$config$`