### PR TITLE
Add wildcard support for contains and render with match()

### DIFF
--- a/library/Director/IcingaConfig/AssignRenderer.php
+++ b/library/Director/IcingaConfig/AssignRenderer.php
@@ -112,11 +112,24 @@ class AssignRenderer
 
     protected function renderContains(FilterExpression $filter)
     {
-        return sprintf(
-            '%s in %s',
-            $this->renderExpressionValue(json_decode($filter->getColumn())),
-            $filter->getExpression()
-        );
+        // Note: expression and column is flipped in this mode
+        $value = json_decode($filter->getColumn());
+        $expression = $this->renderExpressionValue($value);
+        $column = $filter->getExpression();
+
+        if (strpos($value, '*') !== false) {
+            return sprintf(
+                'match(%s, %s, MatchAny)',
+                $expression,
+                $column
+            );
+        } else {
+            return sprintf(
+                '%s in %s',
+                $expression,
+                $column
+            );
+        }
     }
 
     protected function renderFilterExpression(FilterExpression $filter)

--- a/test/php/library/Director/IcingaConfig/AssignRendererTest.php
+++ b/test/php/library/Director/IcingaConfig/AssignRendererTest.php
@@ -93,6 +93,15 @@ class AssignRendererTest extends BaseTestCase
             $expected,
             $this->renderer($string)->renderAssign()
         );
+
+        $string = json_encode('member*') . '=host.vars.some_array';
+
+        $expected = 'assign where match("member*", host.vars.some_array, MatchAny)';
+
+        $this->assertEquals(
+            $expected,
+            $this->renderer($string)->renderAssign()
+        );
     }
 
     public function testInArrayIsRenderedCorrectly()


### PR DESCRIPTION
This used MatchAny explicitly, since we check against an array here.

When a user specifies an filter like this in Director:

    host.groups contains "customer*"

The Director should render it as:

    assign where match("customer*", host.groups, MatchAny)

For backwards compatibility I wouldn't change wildcards with `=`, but for contains this new behavior here should be expected.

ref/NC/620757