### PR TITLE
Fix host templates not usable with hostgroup restrictions

### DIFF
--- a/library/Director/Restriction/HostgroupRestriction.php
+++ b/library/Director/Restriction/HostgroupRestriction.php
@@ -57,11 +57,9 @@ class HostgroupRestriction extends ObjectRestriction
         }
 
         if (! $host->hasBeenLoadedFromDb()) {
-            if ($host->hasModifiedGroups()) {
-                foreach ($this->listRestrictedHostgroups() as $group) {
-                    if ($host->hasGroup($group)) {
-                        return true;
-                    }
+            foreach ($this->listRestrictedHostgroups() as $group) {
+                if ($host->hasGroup($group)) {
+                    return true;
                 }
             }
 


### PR DESCRIPTION
Before, for new hosts the code checked whether the host is part of any
restricted hostgroup only if the host's groups got modified directly.
I honestly don't know how that should be possible, since one can't add
host groups directly if restricted.
Now, for new hosts the code checks whether the resolved host groups
match at least one of the restricted host groups.

fixes #2020 