### PR TITLE
ImportSourceRestApi: Add header and deeper extract_property

### DIFF
--- a/library/Director/Test/BaseTestCase.php
+++ b/library/Director/Test/BaseTestCase.php
@@ -106,4 +106,22 @@ abstract class BaseTestCase extends PHPUnit_Framework_TestCase
 
         return self::$app;
     }
+
+    /**
+     * Call a protected function for a class during testing
+     *
+     * @param       $obj
+     * @param       $name
+     * @param array $args
+     *
+     * @return mixed
+     * @throws \ReflectionException
+     */
+    public static function callMethod($obj, $name, array $args)
+    {
+        $class = new \ReflectionClass($obj);
+        $method = $class->getMethod($name);
+        $method->setAccessible(true);
+        return $method->invokeArgs($obj, $args);
+    }
 }

--- a/test/php/library/Director/Import/ImportSourceRestApiTest.php
+++ b/test/php/library/Director/Import/ImportSourceRestApiTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Tests\Icinga\Module\Director\Import;
+
+use Icinga\Module\Director\Import\ImportSourceRestApi;
+use Icinga\Module\Director\Test\BaseTestCase;
+
+class ImportSourceRestApiTest extends BaseTestCase
+{
+    public function testExtractProperty()
+    {
+        $examples = [
+            ''                     => json_decode('[{"name":"blau"}]'),
+            'objects'              => json_decode('{"objects":[{"name":"blau"}]}'),
+            'results.objects.all'  => json_decode('{"results":{"objects":{"all":[{"name":"blau"}]}}}'),
+            'results\.objects.all' => json_decode('{"results.objects":{"all":[{"name":"blau"}]}}'),
+        ];
+
+        $source = new ImportSourceRestApi();
+
+        foreach ($examples as $property => $data) {
+            $source->setSettings(['extract_property' => $property]);
+            $result = static::callMethod($source, 'extractProperty', [$data]);
+
+            $this->assertCount(1, $result);
+            $this->assertArrayHasKey('name', (array) $result[0]);
+        }
+    }
+}


### PR DESCRIPTION
Allows a user to add additional headers, e.g. by setting a specific `Accept` or any authentication header.

Also `extract_property` now has a logic for deeper keys like "result.objects", "key.deeper_key.very_deep"