### PR TITLE
Check $view->compact instead of view URL param

### DIFF
--- a/library/Director/Web/Controller/ActionController.php
+++ b/library/Director/Web/Controller/ActionController.php
@@ -206,7 +206,7 @@ abstract class ActionController extends Controller implements ControlsAndContent
             $viewRenderer = new SimpleViewRenderer();
             $viewRenderer->replaceZendViewRenderer();
             $this->view = $viewRenderer->view;
-            if ($this->getOriginalUrl()->getParam('view') === 'compact') {
+            if ($this->view->compact) {
                 if ($this->view->controls) {
                     $this->controls()->getAttributes()->add('style', 'display: none;');
                 }


### PR DESCRIPTION
Starting with Web version 2.8.0 the view=compact URL param has been
deprecated and removed. Before, it was used to set a certain view
to compact mode. We use the showCompact URL parameter for that now.
Note that this parameter has been there forever, so this change is
backwards compatible.

See https://github.com/Icinga/icingaweb2/pull/4164 for details.