### PR TITLE
KickstartForm: add 'UTF8' to array of allowed charsets, to support Po…

### DIFF
--- a/application/forms/KickstartForm.php
+++ b/application/forms/KickstartForm.php
@@ -197,7 +197,7 @@ class KickstartForm extends DirectorForm
         if ($resourceName = $this->getResourceName()) {
             $resourceConfig = ResourceFactory::getResourceConfig($resourceName);
             if (! isset($resourceConfig->charset)
-                || ! in_array($resourceConfig->charset, array('utf8', 'utf8mb4', 'UTF-8'))
+                || ! in_array($resourceConfig->charset, array('utf8', 'utf8mb4', 'UTF8', 'UTF-8'))
             ) {
                 if ($resource = $this->getElement('resource')) {
                     $resource->addError('Please change the encoding for the director database to utf8');


### PR DESCRIPTION
…stgres

Followup to eae7a8ab86f404b20ec425531fbcda5339d94df1

UTF8 without a dash is the proper encoding shown by psql -c '\l'