### PR TITLE
Daemon: start after database

### DIFF
--- a/contrib/systemd/icinga-director.service
+++ b/contrib/systemd/icinga-director.service
@@ -1,7 +1,8 @@
 [Unit]
 Description=Icinga Director - Monitoring Configuration
 Documentation=https://icinga.com/docs/director/latest/
-Wants=network.target
+Wants=network-online.target
+After=mariadb.service mysqld.service postgresql.service
 
 [Service]
 EnvironmentFile=-/etc/default/icinga-director


### PR DESCRIPTION
This changes the daemon to start after network being really up and to wait for a database so it does not start with an error.