### PR TITLE
Fixed: GetHostByAddr: Handle Null

### DIFF
--- a/library/Director/PropertyModifier/PropertyModifierGetHostByAddr.php
+++ b/library/Director/PropertyModifier/PropertyModifierGetHostByAddr.php
@@ -29,7 +29,10 @@ class PropertyModifierGetHostByAddr extends PropertyModifierHook
 
     public function transform($value)
     {
-        $host = gethostbyaddr($value);
+	if ($value === null) {
+	     return null;
+	}
+	$host = gethostbyaddr($value);
         if ($host === false) {
             switch ($this->getSetting('on_failure')) {
                 case 'null':


### PR DESCRIPTION
Modifier GetHostByAddr fails for some reason the value is null. Instead of failing this will return null.
Depending on PHP version Lowercase requires PHP-mbstring which was not listed as a dependency.