### PR TITLE
Fix print cli-output for SyncRule-checks

### DIFF
--- a/application/clicommands/SyncruleCommand.php
+++ b/application/clicommands/SyncruleCommand.php
@@ -67,8 +67,8 @@ class SyncruleCommand extends Command
             $mods = $this->getExpectedModificationCounts($rule);
             printf(
                 "Expected modifications: %dx create, %dx modify, %dx delete\n",
-                $mods->modify,
                 $mods->create,
+                $mods->modify,
                 $mods->delete
             );
         }


### PR DESCRIPTION
printf was using the create-value to populate the modify-output and vice versa. The commit swaps both arguments, so the output matches again.