### PR TITLE
IcingaTimePeriod: make description more clear

### DIFF
--- a/application/forms/IcingaScheduledDowntimeRangeForm.php
+++ b/application/forms/IcingaScheduledDowntimeRangeForm.php
@@ -21,7 +21,7 @@ class IcingaScheduledDowntimeRangeForm extends DirectorObjectForm
         $this->addElement('text', 'range_key', [
             'label'       => $this->translate('Day(s)'),
             'description' => $this->translate(
-                'Might be, monday, tuesday, 2016-01-28 - have a look at the documentation for more examples'
+                'Might be monday, tuesday or 2016-01-28 - have a look at the documentation for more examples'
             ),
         ]);
 

--- a/application/forms/IcingaTimePeriodRangeForm.php
+++ b/application/forms/IcingaTimePeriodRangeForm.php
@@ -20,7 +20,7 @@ class IcingaTimePeriodRangeForm extends DirectorObjectForm
         $this->addElement('text', 'range_key', array(
             'label'       => $this->translate('Day(s)'),
             'description' => $this->translate(
-                'Might be, monday, tuesday, 2016-01-28 - have a look at the documentation for more examples'
+                'Might be monday, tuesday or 2016-01-28 - have a look at the documentation for more examples'
             ),
         ));
 

--- a/application/locale/de_DE/LC_MESSAGES/director.po
+++ b/application/locale/de_DE/LC_MESSAGES/director.po
@@ -3643,10 +3643,10 @@ msgstr "Zusammenführungsrichtlinie"
 #: application/forms/IcingaTimePeriodRangeForm.php:23
 #: application/forms/IcingaScheduledDowntimeRangeForm.php:24
 msgid ""
-"Might be, monday, tuesday, 2016-01-28 - have a look at the documentation for "
+"Might be monday, tuesday or 2016-01-28 - have a look at the documentation for "
 "more examples"
 msgstr ""
-"Mögliche Werte sind z.B. monday, tuesday, 2016-01-28 - Mehr Beispiele finden "
+"Mögliche Werte sind z.B. monday, tuesday oder 2016-01-28 - Mehr Beispiele finden "
 "sich in der Dokumentation"
 
 #: application/forms/IcingaTemplateChoiceForm.php:73

--- a/application/locale/it_IT/LC_MESSAGES/director.po
+++ b/application/locale/it_IT/LC_MESSAGES/director.po
@@ -3429,7 +3429,7 @@ msgstr "Regole su Unisci"
 #: application/forms/IcingaScheduledDowntimeRangeForm.php:24
 #, fuzzy
 msgid ""
-"Might be, monday, tuesday, 2016-01-28 - have a look at the documentation for "
+"Might be monday, tuesday or 2016-01-28 - have a look at the documentation for "
 "more examples"
 msgstr ""
 "Per esempio lunedí, martedí, 2020-01-28 - consulta la documentazione per "

--- a/application/locale/ja_JP/LC_MESSAGES/director.po
+++ b/application/locale/ja_JP/LC_MESSAGES/director.po
@@ -3058,7 +3058,7 @@ msgstr "マージポリシー"
 
 #: ../../../../modules/director/application/forms/IcingaTimePeriodRangeForm.php:23
 msgid ""
-"Might be, monday, tuesday, 2016-01-28 - have a look at the documentation for "
+"Might be monday, tuesday or 2016-01-28 - have a look at the documentation for "
 "more examples"
 msgstr "monday, tuesday, 2016-01-28といった書式で指定します。"
 "より多くの例についてはドキュメントを見てください"


### PR DESCRIPTION
Description was unclear about format.
Looks like you are able to build a comma -separated list:
--> monday, tuesday,...
instead of:
--> monday or tuesday or...