### PR TITLE
Monitoring: Don't fail if module monitoring is not enabled

### DIFF
--- a/library/Director/ProvidedHook/Monitoring/HostActions.php
+++ b/library/Director/ProvidedHook/Monitoring/HostActions.php
@@ -46,7 +46,7 @@ class HostActions extends HostActionsHook
         $auth = Auth::getInstance();
         if (Util::hasPermission('director/monitoring/hosts')) {
             $monitoring = new Monitoring();
-            if ($monitoring->authCanEditHost($auth, $hostname)) {
+            if ($monitoring->isAvailable() && $monitoring->authCanEditHost($auth, $hostname)) {
                 $allowEdit = IcingaHost::exists($hostname, $db);
             }
         }

--- a/library/Director/ProvidedHook/Monitoring/ServiceActions.php
+++ b/library/Director/ProvidedHook/Monitoring/ServiceActions.php
@@ -56,7 +56,10 @@ class ServiceActions extends ServiceActionsHook
             $title = mt('director', 'Modify');
         } elseif (Util::hasPermission('director/monitoring/services')) {
             $monitoring = new Monitoring();
-            if ($monitoring->authCanEditService(Auth::getInstance(), $hostname, $serviceName)) {
+            if (
+                $monitoring->isAvailable()
+                && $monitoring->authCanEditService(Auth::getInstance(), $hostname, $serviceName)
+            ) {
                 $title = mt('director', 'Modify');
             }
         } elseif (Util::hasPermission('director/monitoring/services-ro')) {


### PR DESCRIPTION
Icinga DB Web loads `monitoring`'s action hooks. If there's no backend configured or the module isn't enabled, Director fails if asked for action urls and runs into a fatal error.

* I'd liked to just catch the error, but that's not possible anymore since PHP 8 (`@` doesn't silence fatal errors anymore)
* I considered to provide a fake backend for a moment, but then noticed class `Monitoring` doesn't even ask for one if the module is disabled
* I don't want to patch Director at runtime

Hence, to make the Director work with Icinga DB Web rc2+ this is required.