### PR TITLE
Convert $imports keys to string explicitly

### DIFF
--- a/library/Director/Objects/IcingaObjectImports.php
+++ b/library/Director/Objects/IcingaObjectImports.php
@@ -232,6 +232,7 @@ class IcingaObjectImports implements Iterator, Countable, IcingaConfigRenderer
     {
         $list = [];
         foreach ($this->listImportNames() as $name) {
+            $name = (string) $name;
             $list[$name] = $this->getObject($name);
         }
 


### PR DESCRIPTION
The keys of $imports in IcingaObjectImports must be converted to string explicitly or else it establishes incorrect parent-child relation
in icinga_host_inheritance table in case the key is integer value and there is an host object with id = key(integer) icinga_host table.
This results in undefined offset while triggering sync rule.

[ref/IP/36089](https://rt.icinga.com/Ticket/Display.html?id=36089&results=9fd14bd96eccc7871e1fbc5f10bf4b96)