### PR TITLE
Pass $resolved as False for arguments to toPlainObject()

### DIFF
--- a/library/Director/Objects/IcingaObject.php
+++ b/library/Director/Objects/IcingaObject.php
@@ -2826,7 +2826,7 @@ abstract class IcingaObject extends DbObject implements IcingaConfigRenderer
 
         if ($this instanceof ObjectWithArguments) {
             $props['arguments'] = $this->arguments()->toPlainObject(
-                $resolved,
+                false,
                 $skipDefaults
             );
         }


### PR DESCRIPTION
IcingaArguments passes the $resolved through to the individual argument in the toPlainObject. There lies the error,
simply pass false - because the argument itself cannot have any parents and therefore cannot be resolved

[ref/IP/36053](https://rt.icinga.com/Ticket/Display.html?id=36053)