### PR TITLE
Use hosts deployed from director as url parameters in CubeLinks

### DIFF
--- a/library/Director/ProvidedHook/CubeLinks.php
+++ b/library/Director/ProvidedHook/CubeLinks.php
@@ -2,10 +2,13 @@
 
 namespace Icinga\Module\Director\ProvidedHook;
 
+use Icinga\Application\Config;
 use Icinga\Data\Filter\Filter;
 use Icinga\Module\Cube\Cube;
 use Icinga\Module\Cube\Hook\ActionsHook;
 use Icinga\Module\Cube\Ido\IdoHostStatusCube;
+use Icinga\Module\Director\Db;
+use Icinga\Module\Director\Objects\IcingaObject;
 use Icinga\Web\View;
 
 class CubeLinks extends ActionsHook
@@ -19,6 +22,8 @@ class CubeLinks extends ActionsHook
             return;
         }
 
+        $directorHosts = array_keys(IcingaObject::loadAllByType('Host', $this->directorDb()));
+
         $cube->finalizeInnerQuery();
         $query = $cube->innerQuery()
             ->reset('columns')
@@ -28,31 +33,53 @@ class CubeLinks extends ActionsHook
         $hosts = $cube->db()->fetchCol($query);
 
         $count = count($hosts);
+        $chosenHosts = [];
         if ($count === 1) {
             $url = 'director/host/edit';
-            $params = array('name' => $hosts[0]);
+            if (in_array($hosts[0], $directorHosts)) {
+                $chosenHosts[] = $hosts[0];
+                $params = array('name' => $hosts[0]);
 
-            $title = $view->translate('Modify a host');
-            $description = sprintf(
-                $view->translate('This allows you to modify properties for "%s"'),
-                $hosts[0]
-            );
+                $title = $view->translate('Modify a host');
+                $description = sprintf(
+                    $view->translate('This allows you to modify properties for "%s" (deployed from director)'),
+                    $hosts[0]
+                );
+            }
         } else {
             $params = null;
 
             $filter = Filter::matchAny();
             foreach ($hosts as $host) {
-                $filter->addFilter(
-                    Filter::matchAny(Filter::expression('name', '=', $host))
-                );
+                if (in_array($host, $directorHosts)) {
+                    $chosenHosts[] = $host;
+                    $filter->addFilter(
+                        Filter::matchAny(Filter::expression('name', '=', $host))
+                    );
+                }
             }
 
-            $url = 'director/hosts/edit?' . $filter->toQueryString();
+            if (count($chosenHosts) == 1) {
+                $url = 'director/host/edit';
+                $params = array('name' => $chosenHosts[0]);
 
-            $title = sprintf($view->translate('Modify %d hosts'), $count);
-            $description = $view->translate(
-                'This allows you to modify properties for all chosen hosts at once'
-            );
+                $title = $view->translate('Modify a host');
+                $description = sprintf(
+                    $view->translate('This allows you to modify properties for "%s" (deployed from director)'),
+                    $chosenHosts[0]
+                );
+            } else {
+                $url = 'director/hosts/edit?' . $filter->toQueryString();
+
+                $title = sprintf($view->translate('Modify %d hosts'), count($chosenHosts));
+                $description = $view->translate(
+                    'This allows you to modify properties for all chosen hosts (deployed from director) at once'
+                );
+            }
+        }
+
+        if (! (count($chosenHosts) > 0)) {
+            return;
         }
 
         $this->addActionLink(
@@ -61,5 +88,15 @@ class CubeLinks extends ActionsHook
             $description,
             'wrench'
         );
+    }
+
+    protected function directorDb()
+    {
+        $resourceName = Config::module('director')->get('db', 'resource');
+        if (! $resourceName) {
+            return false;
+        }
+
+        return Db::fromResourceName($resourceName);
     }
 }

--- a/library/Director/ProvidedHook/CubeLinks.php
+++ b/library/Director/ProvidedHook/CubeLinks.php
@@ -2,13 +2,10 @@
 
 namespace Icinga\Module\Director\ProvidedHook;
 
-use Icinga\Application\Config;
 use Icinga\Data\Filter\Filter;
 use Icinga\Module\Cube\Cube;
 use Icinga\Module\Cube\Hook\ActionsHook;
 use Icinga\Module\Cube\Ido\IdoHostStatusCube;
-use Icinga\Module\Director\Db;
-use Icinga\Module\Director\Objects\IcingaObject;
 use Icinga\Web\View;
 
 class CubeLinks extends ActionsHook
@@ -22,8 +19,6 @@ class CubeLinks extends ActionsHook
             return;
         }
 
-        $directorHosts = array_keys(IcingaObject::loadAllByType('Host', $this->directorDb()));
-
         $cube->finalizeInnerQuery();
         $query = $cube->innerQuery()
             ->reset('columns')
@@ -33,53 +28,31 @@ class CubeLinks extends ActionsHook
         $hosts = $cube->db()->fetchCol($query);
 
         $count = count($hosts);
-        $chosenHosts = [];
         if ($count === 1) {
             $url = 'director/host/edit';
-            if (in_array($hosts[0], $directorHosts)) {
-                $chosenHosts[] = $hosts[0];
-                $params = array('name' => $hosts[0]);
+            $params = array('name' => $hosts[0]);
 
-                $title = $view->translate('Modify a host');
-                $description = sprintf(
-                    $view->translate('This allows you to modify properties for "%s" (deployed from director)'),
-                    $hosts[0]
-                );
-            }
+            $title = $view->translate('Modify a host');
+            $description = sprintf(
+                $view->translate('This allows you to modify properties for "%s" (deployed from director)'),
+                $hosts[0]
+            );
         } else {
             $params = null;
 
             $filter = Filter::matchAny();
             foreach ($hosts as $host) {
-                if (in_array($host, $directorHosts)) {
-                    $chosenHosts[] = $host;
-                    $filter->addFilter(
-                        Filter::matchAny(Filter::expression('name', '=', $host))
-                    );
-                }
-            }
-
-            if (count($chosenHosts) == 1) {
-                $url = 'director/host/edit';
-                $params = array('name' => $chosenHosts[0]);
-
-                $title = $view->translate('Modify a host');
-                $description = sprintf(
-                    $view->translate('This allows you to modify properties for "%s" (deployed from director)'),
-                    $chosenHosts[0]
-                );
-            } else {
-                $url = 'director/hosts/edit?' . $filter->toQueryString();
-
-                $title = sprintf($view->translate('Modify %d hosts'), count($chosenHosts));
-                $description = $view->translate(
-                    'This allows you to modify properties for all chosen hosts (deployed from director) at once'
+                $filter->addFilter(
+                    Filter::matchAny(Filter::expression('name', '=', $host))
                 );
             }
-        }
 
-        if (! (count($chosenHosts) > 0)) {
-            return;
+            $url = 'director/hosts/edit?' . $filter->toQueryString();
+
+            $title = sprintf($view->translate('Modify %d hosts'), count($hosts));
+            $description = $view->translate(
+                'This allows you to modify properties for all chosen hosts (deployed from director) at once'
+            );
         }
 
         $this->addActionLink(
@@ -88,15 +61,5 @@ class CubeLinks extends ActionsHook
             $description,
             'wrench'
         );
-    }
-
-    protected function directorDb()
-    {
-        $resourceName = Config::module('director')->get('db', 'resource');
-        if (! $resourceName) {
-            return false;
-        }
-
-        return Db::fromResourceName($resourceName);
     }
 }

--- a/library/Director/ProvidedHook/IcingaDbCubeLinks.php
+++ b/library/Director/ProvidedHook/IcingaDbCubeLinks.php
@@ -2,6 +2,7 @@
 
 namespace Icinga\Module\Director\ProvidedHook;
 
+use gipfl\Web\Widget\Hint;
 use Icinga\Application\Config;
 use Icinga\Data\Filter\Filter;
 use Icinga\Exception\ProgrammingError;
@@ -9,7 +10,7 @@ use Icinga\Module\Cube\BaseCube;
 use Icinga\Module\Cube\Hook\IcingadbHook;
 use Icinga\Module\Cube\HostCube;
 use Icinga\Module\Director\Db;
-use Icinga\Module\Director\Objects\IcingaObject;
+use Icinga\Module\Director\Objects\IcingaHost;
 use Icinga\Web\View;
 
 class IcingaDbCubeLinks extends IcingadbHook
@@ -22,11 +23,9 @@ class IcingaDbCubeLinks extends IcingadbHook
      */
     public function prepareActionLinks(BaseCube $cube, View $view)
     {
-        if ( ! $cube instanceof HostCube) {
+        if (! $cube instanceof HostCube) {
             return;
         }
-
-        $directorHosts = array_keys(IcingaObject::loadAllByType('Host', $this->directorDb()));
 
         $hosts = [];
         foreach ($cube->getQuery()->getHostNames($cube->getSlices()) as $host) {
@@ -34,26 +33,20 @@ class IcingaDbCubeLinks extends IcingadbHook
         }
 
         $count = count($hosts);
-        $chosenHosts = [];
         if ($count === 1) {
             $url = 'director/host/edit';
-            if (in_array($hosts[0], $directorHosts)) {
-                $chosenHosts[] = $hosts[0];
-                $params = array('name' => $hosts[0]);
-                $title = $view->translate('Modify a host');
-                $description = sprintf(
-                    $view->translate('This allows you to modify properties for "%s" (deployed from director)'),
-                    $chosenHosts[0]
-                );
-            }
-
+            $params = array('name' => $hosts[0]);
+            $title = $view->translate('Modify a host');
+            $description = sprintf(
+                $view->translate('This allows you to modify properties for "%s" (deployed from director)'),
+                $hosts[0]
+            );
         } else {
             $params = null;
 
             $filter = Filter::matchAny();
             foreach ($hosts as $host) {
-                if (in_array($host, $directorHosts)) {
-                    $chosenHosts[] = $host;
+                if (IcingaHost::exists(['object_name' => $host], $this->directorDb())) {
                     $filter->addFilter(
                         Filter::matchAny(Filter::expression('name', '=', $host))
                     );
@@ -61,23 +54,10 @@ class IcingaDbCubeLinks extends IcingadbHook
             }
 
             $url = 'director/hosts/edit?' . $filter->toQueryString();
-
-            if (count($chosenHosts) == 1) {
-                $title = $view->translate('Modify a host');
-                $description = sprintf(
-                    $view->translate('This allows you to modify properties for "%s" (deployed from director)'),
-                    $chosenHosts[0]
-                );
-            } else {
-                $title = sprintf($view->translate('Modify %d hosts'), count($chosenHosts));
-                $description = $view->translate(
-                    'This allows you to modify properties for all chosen hosts (deployed from director) at once'
-                );
-            }
-        }
-
-        if (! (count($chosenHosts) > 0)) {
-            return;
+            $title = sprintf($view->translate('Modify %d hosts'), count($hosts));
+            $description = $view->translate(
+                'This allows you to modify properties for all chosen hosts (deployed from director) at once'
+            );
         }
 
         $this->addActionLink(


### PR DESCRIPTION
In case there were none of the hosts showed in a dimension for the cube module, then do not show the CubeLinks for that dimension.

fixes #2437 