### PR TITLE
fix: use bell icon for notifications

### DIFF
--- a/library/Director/Dashboard/Dashlet/NotificationApplyDashlet.php
+++ b/library/Director/Dashboard/Dashlet/NotificationApplyDashlet.php
@@ -4,7 +4,7 @@ namespace Icinga\Module\Director\Dashboard\Dashlet;
 
 class NotificationApplyDashlet extends Dashlet
 {
-    protected $icon = 'megaphone';
+    protected $icon = 'bell';
 
     protected $requiredStats = array('notification');
 

--- a/library/Director/Dashboard/Dashlet/NotificationsDashlet.php
+++ b/library/Director/Dashboard/Dashlet/NotificationsDashlet.php
@@ -4,7 +4,7 @@ namespace Icinga\Module\Director\Dashboard\Dashlet;
 
 class NotificationsDashlet extends Dashlet
 {
-    protected $icon = 'megaphone';
+    protected $icon = 'bell';
 
     protected $requiredStats = array('notification');
 


### PR DESCRIPTION
I believe the `bell` icon is more appropriate for directors use-case since icingaweb seems to use `megaphone` for announcements in "System" > "Announcements":

![image](https://user-images.githubusercontent.com/116588/148107602-d6186c09-c291-4fe0-b183-c40bdd6b8633.png)

and `bell` is used in "History":

![image](https://user-images.githubusercontent.com/116588/148107508-6ab2069f-f7c3-4fc0-a198-aca136558ce0.png)

as far as i understand the icingaweb2 source, as a noob to it, this should make the iconography in the ui more consistent.