### PR TITLE
Avoid passing non-string args to `ctype_*()` functions

### DIFF
--- a/library/Director/Data/ValueFilter/FilterInt.php
+++ b/library/Director/Data/ValueFilter/FilterInt.php
@@ -8,11 +8,11 @@ class FilterInt implements ValueFilter
 {
     public function filter($value)
     {
-        if ($value === '') {
+        if ($value === '' || $value === null) {
             return null;
         }
 
-        if (! ctype_digit($value)) {
+        if (is_string($value) && ! ctype_digit($value)) {
             return $value;
         }
 

--- a/library/Director/Web/Table/QuickTable.php
+++ b/library/Director/Web/Table/QuickTable.php
@@ -473,7 +473,7 @@ abstract class QuickTable implements Paginatable, ValidHtml
     protected function valueToTimestamp($value)
     {
         // We consider integers as valid timestamps. Does not work for URL params
-        if (ctype_digit($value)) {
+        if (! is_string($value) || ctype_digit($value)) {
             return $value;
         }
         $value = strtotime($value);


### PR DESCRIPTION
https://www.php.net/manual/en/migration81.deprecated.php#migration81.deprecated.ctype