### PR TITLE
Added possibility of using functions in fields of type string

### DIFF
--- a/library/Director/IcingaConfig/IcingaConfigHelper.php
+++ b/library/Director/IcingaConfig/IcingaConfigHelper.php
@@ -123,34 +123,38 @@ class IcingaConfigHelper
     //       Parameter? Dedicated method? Always if \n is found?
     public static function renderString($string)
     {
-        $special = [
-            '/\\\/',
-            '/"/',
-            '/\$/',
-            '/\t/',
-            '/\r/',
-            '/\n/',
-            // '/\b/', -> doesn't work
-            '/\f/',
-        ];
-
-        $replace = [
-            '\\\\\\',
-            '\\"',
-            '\\$',
-            '\\t',
-            '\\r',
-            '\\n',
-            // '\\b',
-            '\\f',
-        ];
-
-        $string = preg_replace($special, $replace, $string);
-
         if(substr($string, 0, 2) === "@@"){
+
             return substr($string, 2);
+
         } else {
+
+            $special = [
+                '/\\\/',
+                '/"/',
+                '/\$/',
+                '/\t/',
+                '/\r/',
+                '/\n/',
+                // '/\b/', -> doesn't work
+                '/\f/',
+            ];
+
+            $replace = [
+                '\\\\\\',
+                '\\"',
+                '\\$',
+                '\\t',
+                '\\r',
+                '\\n',
+                // '\\b',
+                '\\f',
+            ];
+
+            $string = preg_replace($special, $replace, $string);
+
             return '"' . $string . '"';
+
         }
     }
 

--- a/library/Director/IcingaConfig/IcingaConfigHelper.php
+++ b/library/Director/IcingaConfig/IcingaConfigHelper.php
@@ -147,7 +147,11 @@ class IcingaConfigHelper
 
         $string = preg_replace($special, $replace, $string);
 
-        return '"' . $string . '"';
+        if(substr($string, 0, 2) === "@@"){
+            return substr($string, 2);
+        } else {
+            return '"' . $string . '"';
+        }
     }
 
     public static function renderPhpValue($value)


### PR DESCRIPTION
Strings starting with "@@" will be rendered without quotes. This will allow us to use the Icinga2 functions in the director.
https://icinga.com/docs/icinga-2/latest/doc/18-library-reference/#object-accessor-functions