### PR TITLE
Compatibility with ipl v0.8.0

### DIFF
--- a/doc/02-Installation.md
+++ b/doc/02-Installation.md
@@ -16,17 +16,15 @@ Requirements
   * Some features require newer Icinga 2 releases
     * Flapping requires 2.8 for the thresholds to work - and at least 2.7 on all
       nodes
-* Icinga Web 2 (&gt;= 2.6.0). All versions since 2.2 should also work fine, but
-  might show smaller UI bugs and are not actively tested
+* Icinga Web 2 (&gt;= 2.9.0)
+* [Icinga PHP Library (ipl)](https://github.com/Icinga/icinga-php-library) (>= 0.8)
+* [Icinga PHP Thirdparty](https://github.com/Icinga/icinga-php-thirdparty) (>= 0.10)
 * The following Icinga modules must be installed and enabled:
   * [incubator](https://github.com/Icinga/icingaweb2-module-incubator) (>=0.5.0)
-  * If you are using Icinga Web &lt; 2.9.0, the following modules are also required
-    * [ipl](https://github.com/Icinga/icingaweb2-module-ipl) (>=0.3.0)
-    * [reactbundle](https://github.com/Icinga/icingaweb2-module-reactbundle) (>=0.7.0)
 * A database, MySQL (&gt;= 5.1) or PostgreSQL (&gt;= 9.1). MariaDB and other
   MySQL forks are also fine. Mentioned versions are the required minimum,
   for MySQL we suggest using at least 5.5.3, for PostgreSQL 9.4.
-* PHP (>= 5.6.3). For best performance please use 7.x or 8.x
+* PHP (>= 7.2)
 * php-pdo-mysql and/or php-pdo-pgsql
 * php-curl
 * php-iconv

--- a/library/Director/Dashboard/Dashboard.php
+++ b/library/Director/Dashboard/Dashboard.php
@@ -149,7 +149,7 @@ abstract class Dashboard extends HtmlDocument
         ]);
     }
 
-    public function count()
+    public function count(): int
     {
         return count($this->dashlets());
     }

--- a/module.info
+++ b/module.info
@@ -1,6 +1,8 @@
 Name: Icinga Director
 Version: master
-Depends: reactbundle (>=0.9.0), ipl (>=0.5.0), incubator (>=0.11.0)
+Requires:
+  Libraries: icinga-php-library (>=0.8.0), icinga-php-thirdparty (>=0.10.0)
+  Modules: incubator (>=0.11.0)
 Description: Director - Config tool for Icinga 2
  Icinga Director is a configuration tool that has been designed to make
  Icinga 2 configuration easy and understandable.


### PR DESCRIPTION
With the next non-patch release of the IPL, it will require PHP 7.2 at a minimum and adds support for up to PHP 8.1. This means that some interfaces will change. For example `ipl\Html\HtmlDocument::count()` will change to `ipl\Html\HtmlDocument::count(): int`. This is addressed here for the `Icinga\Module\Director\Dashboard\Dashboard` abstract class.

This also means that the Director has to raise it's minimum required version of Icinga Web 2 up to v2.9, as otherwise it's not possible to install the IPL in v0.8.0.

I've also thought about just not overriding `ipl\Html\HtmlDocument::count(): int` and instead patch `Icinga\Module\Director\Dashboard\Dashboard::isAvailable()` as that wouldn't require any dependency upgrades, as far as I know, since this is the only case I've identified.

But since there are also some cases in `gipfl\`, I figured it isn't worthwhile since I don't think a similar work-around is possible there.