### PR TITLE
Fix sync rule restore from snapshot on name change

### DIFF
--- a/library/Director/Objects/SyncRule.php
+++ b/library/Director/Objects/SyncRule.php
@@ -315,10 +315,6 @@ class SyncRule extends DbObject implements ExportInterface
         $object->newSyncProperties = $properties['properties'];
         unset($properties['properties']);
         $object->setProperties($properties);
-        if ($id !== null && (int) $id !== (int) $object->get('id')) {
-            $object->originalId = $object->get('id');
-            $object->reallySet('id', $id);
-        }
 
         return $object;
     }


### PR DESCRIPTION
Icinga director throws error when we try to restore sync rule from snapshot of the configuration basket after its name has been changed.

[ref/IP/37949](https://rt.icinga.com/Ticket/Display.html?id=37949#txn-638589)