### PR TITLE
Added multi-select feature for commands

### DIFF
--- a/application/controllers/CommandsController.php
+++ b/application/controllers/CommandsController.php
@@ -3,6 +3,8 @@
 namespace Icinga\Module\Director\Controllers;
 
 use Icinga\Module\Director\Web\Controller\ObjectsController;
+use gipfl\IcingaWeb2\Url;
+use gipfl\IcingaWeb2\Link;
 
 class CommandsController extends ObjectsController
 {
@@ -23,5 +25,28 @@ class CommandsController extends ObjectsController
         }
 
         $this->table->setType($type);
+    }
+
+    public function editAction()
+    {
+        parent::editAction();
+        $objects = $this->loadMultiObjectsFromParams();
+        $names = [];
+        foreach ($objects as $object) {
+            $names[] = $object->getUniqueIdentifier();
+        }
+
+        $url = url::fromPath('director/basket/add', [
+            'type' => 'Command'
+        ]);
+
+        $url->getParams()->addValues('names', $names);
+
+        $this->actions()->add(Link::create(
+            $this->translate('Add to Basket'),
+            $url,
+            null,
+            ['class' => 'icon-tag']
+        ));
     }
 }

--- a/application/controllers/CommandsController.php
+++ b/application/controllers/CommandsController.php
@@ -8,15 +8,15 @@ use gipfl\IcingaWeb2\Link;
 
 class CommandsController extends ObjectsController
 {
+    protected $multiEdit = array(
+        'imports',
+        'timeout',
+        'is_string',
+        'disabled'
+    );
+
     public function indexAction()
     {
-        protected $multiEdit = array(
-          'imports',
-          'timeout',
-          'is_string',
-          'disabled'
-        );
-
         parent::indexAction();
         $validTypes = ['object', 'external_object'];
         $type = $this->params->get('type', 'object');

--- a/application/controllers/CommandsController.php
+++ b/application/controllers/CommandsController.php
@@ -8,6 +8,13 @@ class CommandsController extends ObjectsController
 {
     public function indexAction()
     {
+        protected $multiEdit = array(
+          'imports',
+          'timeout',
+          'is_string',
+          'disabled'
+        );
+
         parent::indexAction();
         $validTypes = ['object', 'external_object'];
         $type = $this->params->get('type', 'object');

--- a/library/Director/Web/Table/ObjectsTableCommand.php
+++ b/library/Director/Web/Table/ObjectsTableCommand.php
@@ -3,9 +3,21 @@
 namespace Icinga\Module\Director\Web\Table;
 
 use Zend_Db_Select as ZfSelect;
+use gipfl\IcingaWeb2\Table\Extension\MultiSelect;
 
 class ObjectsTableCommand extends ObjectsTable implements FilterableByUsage
 {
+    use MultiSelect;
+
+    public function assemble()
+    {
+        $this->enableMultiSelect(
+            'director/commands/edit',
+            'director/commands',
+            ['uuid']
+        );
+    }
+
     // TODO: Notifications separately?
     protected $searchColumns = [
         'o.object_name',


### PR DESCRIPTION
I added support for multi-selection of commands at `Icinga Director > Commands > Commands`.

Right now, the following fields are editable - any more needed?

* `Imports`
* `Timeout`
* `Render as string`
* `Disabled`

Additionally, I added the 'Add to Basket' entry to the multi-selection action bar.

This fixes #2498 