### PR TITLE
Prevent inserting blank entries for extensible data list.

### DIFF
--- a/library/Director/DataType/DataTypeDatalist.php
+++ b/library/Director/DataType/DataTypeDatalist.php
@@ -59,7 +59,9 @@ class DataTypeDatalist extends DataTypeHook
 
                 $db = $form->getDb();
                 foreach ($value as $entry) {
-                    $this->createEntryIfNotExists($db, $listId, $entry);
+                    if ($entry !== '') {
+                        $this->createEntryIfNotExists($db, $listId, $entry);
+                    }
                 }
             });
         }


### PR DESCRIPTION
Before this change, when the value for the data field of data type "Datalist" (and element behaviour is "Extend the list with new values") is blank, then the director throws mysql error for trying to insert a blank entry into data list entry table. 

[ref/IP/33703](https://rt.icinga.com/Ticket/Display.html?id=38958)