### PR TITLE
PropertyModifier: Replace Null with String

### DIFF
--- a/library/Director/PropertyModifier/PropertyModifierReplaceNull.php
+++ b/library/Director/PropertyModifier/PropertyModifierReplaceNull.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Icinga\Module\Director\PropertyModifier;
+
+use Icinga\Module\Director\Hook\PropertyModifierHook;
+use Icinga\Module\Director\Web\Form\QuickForm;
+
+class PropertyModifierReplaceNull extends PropertyModifierHook
+{
+
+    public function getName()
+    {
+        return 'Replace null value with String';
+    }
+    
+    public static function addSettingsFormFields(QuickForm $form)
+    {
+        $form->addElement('text', 'string', array(
+            'label'       => 'Replacement String',
+            'description' => $form->translate('Your replacement string'),
+            'required'    => true,
+        ));
+    }
+
+    public function transform($value)
+    {
+        if ($value === null) {
+            return $this->getSetting('string');
+        } else {
+	    return $value;
+	}  
+    }
+}

--- a/register-hooks.php
+++ b/register-hooks.php
@@ -45,6 +45,7 @@ use Icinga\Module\Director\PropertyModifier\PropertyModifierRegexSplit;
 use Icinga\Module\Director\PropertyModifier\PropertyModifierRejectOrSelect;
 use Icinga\Module\Director\PropertyModifier\PropertyModifierRenameColumn;
 use Icinga\Module\Director\PropertyModifier\PropertyModifierReplace;
+use Icinga\Module\Director\PropertyModifier\PropertyModifierReplaceNull;
 use Icinga\Module\Director\PropertyModifier\PropertyModifierSimpleGroupBy;
 use Icinga\Module\Director\PropertyModifier\PropertyModifierSkipDuplicates;
 use Icinga\Module\Director\PropertyModifier\PropertyModifierSplit;
@@ -118,6 +119,7 @@ $directorHooks = [
         PropertyModifierRejectOrSelect::class,
         PropertyModifierRenameColumn::class,
         PropertyModifierReplace::class,
+        PropertyModifierReplaceNull::class,
         PropertyModifierSimpleGroupBy::class,
         PropertyModifierSkipDuplicates::class,
         PropertyModifierSplit::class,


### PR DESCRIPTION
Because of recent fix of the PropertyModifiers to keep null values, instead of replacing with an empty string, there is no longer an option to replace a null value with a string. 

So @dgoetz helped me create a new PropertyModifier to be used instead. A test was successful. 

Ref/NC/750293 