### PR TITLE
Add hasBasketSupport for TimePeriods

### DIFF
--- a/application/controllers/TimeperiodController.php
+++ b/application/controllers/TimeperiodController.php
@@ -30,4 +30,9 @@ class TimeperiodController extends ObjectController
         $this->content()->add($form->handleRequest());
         IcingaTimePeriodRangeTable::load($object)->renderTo($this);
     }
+
+    protected function hasBasketSupport()
+    {
+        return true;
+    }
 }


### PR DESCRIPTION
This adds the missing "hasBasketSupport" for TimePeriodController which allows to add the TimePeriod to specific baskets.

Fixes [Missing "Add to basket" for TimePeriods #2542 ](https://github.com/Icinga/icingaweb2-module-director/issues/2542)