### PR TITLE
Handle cases when gipfl/linux-health returns false instead of memory …

### DIFF
--- a/library/Director/Web/Widget/BackgroundDaemonDetails.php
+++ b/library/Director/Web/Widget/BackgroundDaemonDetails.php
@@ -114,7 +114,7 @@ class BackgroundDaemonDetails extends BaseHtmlElement
                         $pid
                     ],
                     Html::tag('pre', $process->command),
-                    Format::bytes($process->memory->rss)
+                    $process->memory === false ? 'n/a' : Format::bytes($process->memory->rss)
                 ]));
             }
             $this->add($table);


### PR DESCRIPTION
The module gipfl/linux-health, which Directory uses to read memory usage for the background daemon, returns false if the system doesn't have a /proc-filesystem. This causes the WebUI to fail with an error. This patch allows the WebUI to work and instead shows "n/a" for memory usage in such case.