### PR TITLE
IcingaCommand: Remove obsolete CLR check

### DIFF
--- a/application/forms/IcingaCommandForm.php
+++ b/application/forms/IcingaCommandForm.php
@@ -28,7 +28,6 @@ class IcingaCommandForm extends DirectorObjectForm
                     'ClusterZoneCheck'   => 'Icinga Cluster Zone Check Command',
                     'IdoCheck'           => 'Ido Check Command',
                     'RandomCheck'        => 'Random Check Command',
-                    'CrlCheck'           => 'Crl Check Command',
                 )
             ),
             'required'    => ! $this->isTemplate(),

--- a/library/Director/Objects/IcingaCommand.php
+++ b/library/Director/Objects/IcingaCommand.php
@@ -66,7 +66,6 @@ class IcingaCommand extends IcingaObject implements ObjectWithArguments, ExportI
         'ClusterZoneCheck' => 'plugin-check-command',
         'IdoCheck'         => 'ido-check-command',
         'RandomCheck'      => 'random-check-command',
-        'CrlCheck'         => 'clr-check-command',
     ];
 
     /**


### PR DESCRIPTION
According to https://github.com/Icinga/icinga2/pull/6055 this feature was removed from Icinga 2.