### PR TITLE
Fix multi-renaming-issue refs #2497

### DIFF
--- a/application/forms/IcingaMultiEditForm.php
+++ b/application/forms/IcingaMultiEditForm.php
@@ -248,10 +248,15 @@ class IcingaMultiEditForm extends DirectorObjectForm
             $key = 'vars.' . substr($key, 4);
         }
 
-        foreach ($this->objects as $name => $object) {
+        foreach ($this->objects as $object) {
+            $name = $object->getObjectName();
             $value = json_encode($object->$key);
             if (! array_key_exists($value, $variants)) {
                 $variants[$value] = array();
+            }
+
+            if($object->getProperty("object_type") === "object" && strtolower($object->get("type")) === "service"){
+                $name = $object->get("host")."!".$name;
             }
 
             $variants[$value][] = $name;

--- a/library/Director/Web/Controller/ObjectsController.php
+++ b/library/Director/Web/Controller/ObjectsController.php
@@ -407,7 +407,7 @@ abstract class ObjectsController extends ActionController
                         $objects[$name] = $class::load($name, $db);
                     } elseif ($col === 'uuid') {
                         $object = $store->load($table, Uuid::fromString($ex->getExpression()));
-                        $objects[$object->getObjectName()] = $object;
+                        $objects[$object->getUniqueId()->toString()] = $object;
                     } else {
                         throw new InvalidArgumentException("'$col' is no a valid key component for '$type'");
                     }


### PR DESCRIPTION
$objects[$object->getObjectName()] overwrites services with the same name but doesn't consider the host, so only the last service gets edited.

Since we load the object by uuid we can use the uuid to add the object to the objects array

Best Regards
Nicolas