### PR TITLE
Reset Limit count and offset for `$table` in  HostController::servicesAction

### DIFF
--- a/application/controllers/HostController.php
+++ b/application/controllers/HostController.php
@@ -211,7 +211,8 @@ class HostController extends ObjectController
             ->setAuth($this->Auth())
             ->setHost($host)
             ->setBranch($branch)
-            ->setTitle($this->translate('Individual Service objects'));
+            ->setTitle($this->translate('Individual Service objects'))
+            ->removeQueryLimit();
 
         if (count($table)) {
             $content->add($table);
@@ -225,7 +226,9 @@ class HostController extends ObjectController
                 ->setAuth($this->Auth())
                 ->setBranch($branch)
                 ->setHost($parent)
-                ->setInheritedBy($host);
+                ->setInheritedBy($host)
+                ->removeQueryLimit();
+
             if (count($table)) {
                 $content->add(
                     $table->setTitle(sprintf(
@@ -253,6 +256,7 @@ class HostController extends ObjectController
                     ->setBranch($branch)
                     ->setAffectedHost($host)
                     ->setTitle($title)
+                    ->removeQueryLimit()
             );
         }
 

--- a/library/Director/Web/Table/IcingaServiceSetServiceTable.php
+++ b/library/Director/Web/Table/IcingaServiceSetServiceTable.php
@@ -247,4 +247,13 @@ class IcingaServiceSetServiceTable extends ZfQueryBasedTable
         $deleteLink->handleRequest();
         return $deleteLink;
     }
+
+    public function removeQueryLimit()
+    {
+        $query = $this->getQuery();
+        $query->reset($query::LIMIT_OFFSET);
+        $query->reset($query::LIMIT_COUNT);
+
+        return $this;
+    }
 }

--- a/library/Director/Web/Table/ObjectsTable.php
+++ b/library/Director/Web/Table/ObjectsTable.php
@@ -303,4 +303,13 @@ class ObjectsTable extends ZfQueryBasedTable
 
         return $query;
     }
+
+    public function removeQueryLimit()
+    {
+        $query = $this->getQuery();
+        $query->reset($query::LIMIT_OFFSET);
+        $query->reset($query::LIMIT_COUNT);
+
+        return $this;
+    }
 }


### PR DESCRIPTION
The limit in ObjectsTable::prepareQuery() limits the number of services shown in HostController::servicesAction. But this limit is required for pagination in ServicesController. Hence, reset the limit when this query is used in HostController::servicesAction().

[ref/IP/42836](https://rt.icinga.com/Ticket/Display.html?id=42836)