### PR TITLE
Preserve `object_type` for new objects while triggering a SyncRule

### DIFF
--- a/library/Director/Import/Sync.php
+++ b/library/Director/Import/Sync.php
@@ -503,7 +503,7 @@ class Sync
                         $props = [];
                     } else {
                         $props = [
-                            'object_type' => 'object',
+                            'object_type' => $row->object_type ?? 'object',
                             'object_name' => $originalKey,
                         ];
                     }


### PR DESCRIPTION
The `object_type` while preparing new objects was set to `object` without checking whether the `object_type` property of the corresponding objects had been set. Hence, the notifications or other objects with `object_type` `apply` was not working.

fixes #2142 