### PR TITLE
GroupMembershipResolver: do not perform a recheck when dealing with hostgroups

### DIFF
--- a/library/Director/Objects/GroupMembershipResolver.php
+++ b/library/Director/Objects/GroupMembershipResolver.php
@@ -23,6 +23,9 @@ abstract class GroupMembershipResolver
     /** @var string Object type, 'host', 'service', 'user' or similar */
     protected $type;
 
+    /** @var string */
+    protected $resolverForType = '';
+
     /** @var array */
     protected $existingMappings;
 
@@ -55,10 +58,11 @@ abstract class GroupMembershipResolver
 
     protected $groupMap;
 
-    public function __construct(Db $connection)
+    public function __construct(Db $connection, $resolverForType = '')
     {
         $this->connection = $connection;
         $this->db = $connection->getDbAdapter();
+        $this->resolverForType = $resolverForType;
     }
 
     /**
@@ -82,7 +86,10 @@ abstract class GroupMembershipResolver
         }
 
         Benchmark::measure('Rechecking all objects');
-        $this->recheckAllObjects($this->getAppliedGroups());
+        // Only perform a recheck if we are not dealing with hostgroups at the beginning
+        if ($this->resolverForType !== 'hostgroup') {
+            $this->recheckAllObjects($this->getAppliedGroups());
+        }
         if (empty($this->objects) && empty($this->groups)) {
             Benchmark::measure('Nothing to check, got no qualified object');
             return $this;

--- a/library/Director/Objects/IcingaHostGroup.php
+++ b/library/Director/Objects/IcingaHostGroup.php
@@ -18,7 +18,7 @@ class IcingaHostGroup extends IcingaObjectGroup
     {
         if ($this->hostgroupMembershipResolver === null) {
             $this->hostgroupMembershipResolver = new HostGroupMembershipResolver(
-                $this->getConnection()
+                $this->getConnection(), 'hostgroup'
             );
         }
 


### PR DESCRIPTION
Hello,

I know this fix is probably dirty, but I will be happy to amend this PR and make changes.

The point of this PR is an attempt to fix an issue we are currently facing with Icinga director: when adding a hostgroup Director performs a recheck of all hosts declared within Icinga, which is not scalable at all.

We have thousands of hosts, and creating one new hostgroup through director can take up to 10 minutes now.

After testing on our infrastructure, I still don't really get the point of this all recheck thing, but what I did get is that when creating a host we indeed update some mappings in DB, so even though I don't get the final aim of this, I get that some things are Updated in DB.

However, when creating/deleting hostgroups, I never managed to end up in a case where this whole recheck thing is relevant: the diff always ends up being 0 after the recheck so no mapping needs to be updated.

I don't see the point of iterating over all hosts when adding a new hostgroup (when we add a host we just recheck the host itself but not other hosts). So I just tried to ignore this recheck when dealing with hostgroups.

Again, I'll happily make changes if I can understand what's at stake if I change the code the way I changed it and if this can raise some issues.