### PR TITLE
Fix duplicate service sets on clone service refs #2671

### DIFF
--- a/application/forms/IcingaCloneObjectForm.php
+++ b/application/forms/IcingaCloneObjectForm.php
@@ -251,6 +251,7 @@ class IcingaCloneObjectForm extends DirectorForm
         return $db->fetchPairs(
             $db->select()
                 ->from('icinga_service_set', ['id', 'object_name'])
+                ->where('object_type = ?','template')
                 ->order('object_name')
         );
     }


### PR DESCRIPTION
i tried to clone the service from the serviceset to the 'service set' on the host which was in my case some of the other servicesets with the same name.
it gets created by it is inaccessable. 

conclusio:
* do not clone a service from a service set to a serviceset that is on a host
* ->where('object_type = ?','template')