### PR TITLE
Add global element for default group behavior.

### DIFF
--- a/application/forms/SettingsForm.php
+++ b/application/forms/SettingsForm.php
@@ -39,6 +39,25 @@ class SettingsForm extends DirectorForm
             'value'  => $settings->getStoredValue('default_global_zone')
         ));
 
+        $this->addElement('select', 'default_group_behaviour', array(
+            'label'        => $this->translate('Default group behaviour'),
+            'multiOptions' => $this->eventuallyConfiguredEnum(
+                'default_group_behaviour',
+                array(
+                    'assign' => $this->translate('Assign'),
+                    'add' => $this->translate('Add'),
+                    // Remove (-=) is a group option but global remove isn't useful as all groups would be removed all the time.
+                )
+            ),
+            'description'  => $this->translate(
+                'Icinga Director deploys group objects using the operator assign (=)'
+                . ', which overrides groups set in inherited objects, by default.'
+                . ' This option allows you to adjust the group operator globally to'
+                . ' add (+=) which appends groups from inherited objects.'
+            ),
+            'value'  => $settings->getStoredValue('default_group_behaviour')
+        ));
+
         $this->addElement('text', 'icinga_package_name', array(
             'label'        => $this->translate('Icinga Package Name'),
             'description'  => $this->translate(

--- a/library/Director/Objects/IcingaObjectGroups.php
+++ b/library/Director/Objects/IcingaObjectGroups.php
@@ -22,6 +22,8 @@ class IcingaObjectGroups implements Iterator, Countable, IcingaConfigRenderer
 
     protected $object;
 
+    private $operator;
+
     private $position = 0;
 
     protected $idx = array();
@@ -35,6 +37,10 @@ class IcingaObjectGroups implements Iterator, Countable, IcingaConfigRenderer
             $class = $this->getGroupClass();
             $class::prefetchAll($this->object->getConnection());
         }
+        
+        // Set the default operator from global config
+        $settings = $this->object->getConnection()->settings();
+        $this->operator($settings->get('default_group_behaviour'));
     }
 
     #[\ReturnTypeWillChange]
@@ -52,6 +58,11 @@ class IcingaObjectGroups implements Iterator, Countable, IcingaConfigRenderer
     public function hasBeenModified()
     {
         return $this->modified;
+    }
+
+    public function operator($val)
+    {
+        $this->operator = $val;
     }
 
     #[\ReturnTypeWillChange]
@@ -363,7 +374,13 @@ class IcingaObjectGroups implements Iterator, Countable, IcingaConfigRenderer
             return '';
         }
 
-        return c::renderKeyValue('groups', c::renderArray($groups));
+        if ($this->operator === "add") {
+            return c::renderKeyOperatorValue('groups', "+=", c::renderArray($groups));
+        } elseif ($this->operator === "remove") {
+            return c::renderKeyOperatorValue('groups', "-=", c::renderArray($groups));
+        } else {	
+            return c::renderKeyValue('groups', c::renderArray($groups));
+	    }
     }
 
     public function toLegacyConfigString($additionalGroups = array())
@@ -376,7 +393,13 @@ class IcingaObjectGroups implements Iterator, Countable, IcingaConfigRenderer
         }
 
         $type = $this->object->getLegacyObjectType();
-        return c1::renderKeyValue($type.'groups', c1::renderArray($groups));
+        if ($this->operator === "add") {
+            return c1::renderKeyOperatorValue('groups', "+=", c1::renderArray($groups));
+        } elseif ($this->operator == "remove") {
+            return c1::renderKeyOperatorValue('groups', "-=", c1::renderArray($groups));
+        } else {	
+            return c1::renderKeyValue($type.'groups', c1::renderArray($groups));
+        }
     }
 
     public function __toString()

--- a/library/Director/Settings.php
+++ b/library/Director/Settings.php
@@ -12,6 +12,7 @@ class Settings
 
     protected $defaults = [
         'default_global_zone'              => 'director-global',
+        'default_group_behaviour'          => 'assign',
         'icinga_package_name'              => 'director',
         'config_format'                    => 'v2',
         'override_services_varname'        => '_override_servicevars',


### PR DESCRIPTION
Add Global Director Settings for group behavior so it can be changed from the current default of assignment (=) to append (+=). 

- Add global element for default group behavior.
- Add default value 'assign' for default group behavior which matches group behavior . 
- Add logic to IcingaObjectGroups so the class initializes the with the global group behavior and sets the group operator based on the class operator. 

Partial Fix for #344, #636, #824, #2273