### PR TITLE
Fix broken Service Sets page

### DIFF
--- a/library/Director/Web/Table/ObjectSetTable.php
+++ b/library/Director/Web/Table/ObjectSetTable.php
@@ -98,7 +98,7 @@ class ObjectSetTable extends ZfQueryBasedTable
             'object_type'    => 'os.object_type',
             'assign_filter'  => 'os.assign_filter',
             'description'    => 'os.description',
-            'service_object_name' => 'o.object_name',
+            'service_object_name' => 'os.object_name',
             'count_services' => 'COUNT(DISTINCT o.uuid)',
         ];
         if ($this->branchUuid) {


### PR DESCRIPTION
I was getting an SQL error on the Director Service Sets page since I got the module updated from v1.10.2 to the latest master code from the repo.

The query was:
```
SELECT os.id, os.uuid, (NULL) AS branch_uuid, os.object_name, os.object_type, os.assign_filter, os.description, o.object_name AS service_object_name, COUNT(DISTINCT o.uuid) AS count_services FROM icinga_service_set AS os
 LEFT JOIN icinga_service AS o ON o.service_set_id = os.id WHERE (os.object_type = 'template') GROUP BY os.uuid,
	os.uuid,
	os.id,
	os.object_name,
	os.object_type,
	os.assign_filter,
	os.description ORDER BY os.object_name ASC LIMIT 25
```

and the error was:
```
ERROR:  column "o.object_name" must appear in the GROUP BY clause or be used in an aggregate function
LINE 1: ...os.object_type, os.assign_filter, os.description, o.object_n...
```

After trying to run this command in psql shell I quickly figured out that there was a typo in one of the parameters: `o.object_name` instead of `os.object_name`.

This PR fixes the typo in the module code.

