### PR TITLE
fix: update filterHostGroupsQuery default argument

### DIFF
--- a/library/Director/Restriction/HostgroupRestriction.php
+++ b/library/Director/Restriction/HostgroupRestriction.php
@@ -131,7 +131,7 @@ class HostgroupRestriction extends ObjectRestriction
      * @param ZfSelect $query
      * @param string $tableAlias
      */
-    protected function filterHostGroupsQuery(ZfSelect $query, $tableAlias = 'o')
+    protected function filterHostGroupsQuery(ZfSelect $query, $tableAlias = 'h')
     {
         if (! $this->isRestricted()) {
             return;


### PR DESCRIPTION
Resolves #2164

Happy to work with the Icinga team on this PR - please let me know if anything needs changing.

When a role restricts users to a particular host group, e.g:

<img width="592" alt="image" src="https://github.com/Icinga/icingaweb2-module-director/assets/4653939/78314a49-3434-40cd-9148-4c46a4d64f68">

The following error is returned when trying to edit any host group:

```
SQLSTATE[42S22]: Column not found: 1054 Unknown column 'o.object_name' in 'where clause', query was: SELECT h.id FROM icinga_hostgroup AS h WHERE (id = '324') AND (o.object_name IN ('example'))
```

This PR updates the filterHostGroupsQuery default argument to 'h', as per the fix outlined suggested in #2164.

I've been using this in our production environment and it doesn't appear to have caused any adverse side effects. 