### PR TITLE
Fix db type error, when hostgroup is accidentially interpreted as integer

### DIFF
--- a/library/Director/Objects/IcingaObjectGroups.php
+++ b/library/Director/Objects/IcingaObjectGroups.php
@@ -183,6 +183,10 @@ class IcingaObjectGroups implements Iterator, Countable, IcingaConfigRenderer
             return $this;
         }
 
+        if (is_int($group)) {
+            $group = (string) $group;
+        }
+
         /** @var IcingaObjectGroup $class */
         $class = $this->getGroupClass();
 


### PR DESCRIPTION

fixes #2821