### PR TITLE
remove gendered specific language. 

### DIFF
--- a/doc/03-Automation.md
+++ b/doc/03-Automation.md
@@ -9,7 +9,7 @@ Generic hints
 -------------
 
 Director keeps all of its configuration in a relational database. So,
-all you need to tell him is how it can reach and access that db. In case
+all you need to tell them is how it can reach and access that db. In case
 you already rolled out Icinga Web 2 you should already be used to handle
 resource definitions.
 

--- a/doc/82-Changelog.md
+++ b/doc/82-Changelog.md
@@ -935,7 +935,7 @@ in case an error occurs.
 ### Large environments
 * FIX: Director tries to raise it's memory limit for certain memory-intensive
   tasks. When granted more (but not infinite) memory however this had the effect
-  that he self-restricted himself to a lower limit (#1222)
+  that he self-restricted themselves to a lower limit (#1222)
 
 ### User Interface
 * FIX: Assignment filters suggested only Host properties, you have been required


### PR DESCRIPTION
Please fix this. This assumes the administrator is identifies as male.
This fixes up the language for that to allow for it to mean any gender.
