### PR TITLE
Add support for 'Dependency Redundancy Groups'

### DIFF
--- a/application/controllers/SuggestController.php
+++ b/application/controllers/SuggestController.php
@@ -356,6 +356,17 @@ class SuggestController extends ActionController
         return $this->fetchTemplateNames('icinga_dependency');
     }
 
+    protected function suggestDependencyRedundancyGroups()
+    {
+        $db = $this->db()->getDbAdapter();
+        $query = $db->select()
+            ->distinct()
+            ->from('icinga_dependency', 'redundancy_group')
+            ->where('redundancy_group IS NOT NULL')
+            ->order('redundancy_group');
+        return $db->fetchCol($query);
+    }
+
     protected function highlight($val, $search)
     {
         $search = ($search);

--- a/application/forms/IcingaDependencyForm.php
+++ b/application/forms/IcingaDependencyForm.php
@@ -257,6 +257,20 @@ class IcingaDependencyForm extends DirectorObjectForm
             }
         }
 
+        $redundancyGroup = $dependency->get('redundancy_group');
+        $this->addElement('text', 'redundancy_group', [
+            'label' => $this->translate('Dependency Redundancy Group'),
+            'description' => $this->translate(
+                'The dependency redundancy group. A name for a group of which'
+                . ' at least one single dependency must be fulfilled for the'
+                . ' whole dependency to be fulfilled.'
+            ),
+            'class' => "director-suggest",
+            'data-suggestion-context' => 'dependencyredundancygroups',
+            'required' => false,
+            'value' => $redundancyGroup
+        ]);
+
         $elements = ['parent_host', 'child_host', 'parent_service', 'child_service'];
         $this->addDisplayGroup($elements, 'related_objects', [
             'decorators' => [

--- a/library/Director/Objects/IcingaDependency.php
+++ b/library/Director/Objects/IcingaDependency.php
@@ -29,6 +29,7 @@ class IcingaDependency extends IcingaObject implements ExportInterface
         'ignore_soft_states'     => null,
         'period_id'              => null,
         'zone_id'                => null,
+        'redundancy_group'       => null,
         'assign_filter'          => null,
         'parent_service_by_name' => null,
     ];

--- a/library/Director/Web/Form/DirectorObjectForm.php
+++ b/library/Director/Web/Form/DirectorObjectForm.php
@@ -553,6 +553,7 @@ abstract class DirectorObjectForm extends DirectorForm
             'email',
             'pager',
             'enable_notifications',
+            'redundancy_group', //Dependencies
             'disable_checks', //Dependencies
             'disable_notifications',
             'ignore_soft_states',

--- a/schema/mysql-migrations/upgrade_188.sql
+++ b/schema/mysql-migrations/upgrade_188.sql
@@ -1,0 +1,6 @@
+ALTER TABLE icinga_dependency ADD COLUMN redundancy_group VARCHAR(255) DEFAULT NULL AFTER parent_service_by_name;
+ALTER TABLE branched_icinga_dependency ADD COLUMN redundancy_group VARCHAR(255) DEFAULT NULL AFTER parent_service_by_name;
+
+INSERT INTO director_schema_migration
+  (schema_version, migration_time)
+  VALUES (188, NOW());

--- a/schema/mysql.sql
+++ b/schema/mysql.sql
@@ -1774,6 +1774,7 @@ CREATE TABLE icinga_dependency (
   zone_id INT(10) UNSIGNED DEFAULT NULL,
   assign_filter TEXT DEFAULT NULL,
   parent_service_by_name VARCHAR(255) DEFAULT NULL,
+  redundancy_group VARCHAR(255) DEFAULT NULL,
   PRIMARY KEY (id),
   UNIQUE INDEX uuid (uuid),
   CONSTRAINT icinga_dependency_parent_host
@@ -2431,6 +2432,7 @@ CREATE TABLE branched_icinga_dependency (
   zone VARCHAR(255) DEFAULT NULL,
   assign_filter TEXT DEFAULT NULL,
   parent_service_by_name VARCHAR(255) DEFAULT NULL,
+  redundancy_group VARCHAR(255) DEFAULT NULL,
 
   imports TEXT DEFAULT NULL,
   set_null TEXT DEFAULT NULL,
@@ -2446,4 +2448,4 @@ CREATE TABLE branched_icinga_dependency (
 
 INSERT INTO director_schema_migration
   (schema_version, migration_time)
-  VALUES (187, NOW());
+  VALUES (188, NOW());

--- a/schema/pgsql-migrations/upgrade_188.sql
+++ b/schema/pgsql-migrations/upgrade_188.sql
@@ -1,0 +1,6 @@
+ALTER TABLE icinga_dependency ADD COLUMN redundancy_group character varying(255);
+ALTER TABLE branched_icinga_dependency ADD COLUMN redundancy_group character varying(255);
+
+INSERT INTO director_schema_migration
+  (schema_version, migration_time)
+  VALUES (188, NOW());

--- a/schema/pgsql.sql
+++ b/schema/pgsql.sql
@@ -2062,6 +2062,7 @@ CREATE TABLE icinga_dependency (
   zone_id integer DEFAULT NULL,
   assign_filter text DEFAULT NULL,
   parent_service_by_name character varying(255),
+  redundancy_group character varying(255),
   PRIMARY KEY (id),
   CONSTRAINT icinga_dependency_parent_host
     FOREIGN KEY (parent_host_id)
@@ -2768,6 +2769,7 @@ CREATE TABLE branched_icinga_dependency (
   zone_id integer DEFAULT NULL,
   assign_filter text DEFAULT NULL,
   parent_service_by_name character varying(255),
+  redundancy_group character varying(255),
 
   imports TEXT DEFAULT NULL,
   set_null TEXT DEFAULT NULL,
@@ -2785,4 +2787,4 @@ CREATE INDEX branched_dependency_search_object_name ON branched_icinga_dependenc
 
 INSERT INTO director_schema_migration
   (schema_version, migration_time)
-  VALUES (187, NOW());
+  VALUES (188, NOW());


### PR DESCRIPTION
Icinga2 version 2.14.0 introduced **dependency redundancy groups** which allow for more flexiblity when it comes to determining the "reachability" of a host (e.g. multiple DNS servers as redundant dependencies).

This PR adds a new attribute "*redundancy_group*" to dependencies and adjusts the web forms accordingly.

![form](https://github.com/Icinga/icingaweb2-module-director/assets/88634789/69f7f26d-eceb-470c-8811-799c24c3f05d)

![rendered](https://github.com/Icinga/icingaweb2-module-director/assets/88634789/023f69d4-8828-443d-ba68-fc2011c273a8)

---

If any changes need to be made, please let me know.
