### PR TITLE
Unhide imports from Choices when doing multiedit

### DIFF
--- a/application/forms/IcingaMultiEditForm.php
+++ b/application/forms/IcingaMultiEditForm.php
@@ -230,6 +230,9 @@ class IcingaMultiEditForm extends DirectorObjectForm
             $checksum = sha1($json) . '_' . sha1(json_encode($objects));
 
             $v = clone($element);
+            if ($key == "imports") {
+                $v->setAttrib('hideOptions', []);
+            }
             $v->setName($key . '_' . $checksum);
             $v->setDescription($description . ' ' . $this->descriptionForObjects($objects));
             $v->setLabel($label . $this->labelCount($objects));


### PR DESCRIPTION
When doing an multiedit the Choises are not shown but the corresponding Host templates are filtered from the imports.
And if you then do a save the imports are removed from the hosts. see issue #1203

This small patch unhides the filtered host templates when doing an multiedit.

The nicer solution is showing the choices as well in the multiedit, but that is much more complicated code change :)