### PR TITLE
Make unique constraints consistent across databases

### DIFF
--- a/schema/pgsql-migrations/upgrade_188.sql
+++ b/schema/pgsql-migrations/upgrade_188.sql
@@ -1,0 +1,6 @@
+DROP INDEX IF EXISTS import_row_modifier_prio;
+DROP INDEX IF EXISTS service_branch_object_name;
+
+INSERT INTO director_schema_migration
+  (schema_version, migration_time)
+  VALUES (188, NOW());

--- a/schema/pgsql.sql
+++ b/schema/pgsql.sql
@@ -1619,9 +1619,6 @@ CREATE TABLE import_row_modifier (
 );
 
 CREATE INDEX import_row_modifier_search_idx ON import_row_modifier (property_name);
-CREATE UNIQUE INDEX import_row_modifier_prio
-  ON import_row_modifier (source_id, priority);
-
 
 CREATE TABLE import_row_modifier_setting (
   row_modifier_id serial,
@@ -2637,7 +2634,6 @@ CREATE TABLE branched_icinga_service (
           ON UPDATE CASCADE
 );
 
-CREATE UNIQUE INDEX service_branch_object_name ON branched_icinga_service (branch_uuid, object_name);
 CREATE INDEX branched_service_search_object_name ON branched_icinga_service (object_name);
 CREATE INDEX branched_service_search_display_name ON branched_icinga_service (display_name);
 


### PR DESCRIPTION
Unique constraints `import_row_modifier_prio` and `service_branch_object_name` are only present in PostgreSQL and not in MySQL. But the constraints needs to be consistent across databases.

fixes #2270