### PR TITLE
Basket::setObjects: Reset `$chosenObjects` property only if the given objects is empty

### DIFF
--- a/library/Director/DirectorObject/Automation/Basket.php
+++ b/library/Director/DirectorObject/Automation/Basket.php
@@ -82,7 +82,6 @@ class Basket extends DbObject implements ExportInterface
         if (empty($objects)) {
             $this->chosenObjects = [];
         } else {
-            $this->chosenObjects = [];
             foreach ((array) $objects as $type => $object) {
                 $this->addObjects($type, $object);
             }


### PR DESCRIPTION
fix #2901 