### PR TITLE
Fix sync rule preview in case of boolean properties

### DIFF
--- a/library/Director/Db/Branch/BranchedObject.php
+++ b/library/Director/Db/Branch/BranchedObject.php
@@ -3,10 +3,12 @@
 namespace Icinga\Module\Director\Db\Branch;
 
 use Icinga\Exception\NotFoundError;
+use Icinga\Module\Director\Data\Db\DbDataFormatter;
 use Icinga\Module\Director\Data\Db\DbObject;
 use Icinga\Module\Director\Data\Db\DbObjectTypeRegistry;
 use Icinga\Module\Director\Data\Json;
 use Icinga\Module\Director\Db;
+use Icinga\Module\Director\Objects\IcingaObject;
 use Ramsey\Uuid\UuidInterface;
 use stdClass;
 
@@ -198,7 +200,17 @@ class BranchedObject
             }
         }
 
+        $dummyObject = IcingaObject::createByType(
+            $this->objectTable,
+            [],
+            $connection
+        );
+
         foreach ($activity->getModifiedProperties()->jsonSerialize() as $key => $value) {
+            if ($dummyObject->propertyIsBoolean($key)) {
+                $value = DbDataFormatter::normalizeBoolean($value);
+            }
+
             $this->changes[$key] = $value;
         }
 


### PR DESCRIPTION
Sync rules created for import sources, importing objects with boolean properties,  throws `SQLSTATE` error as shown in the screenshot below.

![Sync Preview SQL State error](https://github.com/user-attachments/assets/7c1f27f1-0c98-4945-8599-1e60ea5c9574)

The reason for this is because the preview creates temporary branched objects by importing the objects' properties to check for the modifications. And the boolean properties, were not transformed to `y` or `n` (which is the supported datatype for boolean (`ENUM('y','n')`) to store in the database) before the temporary object is created.

fixes ref/IP/53248