### PR TITLE
IcingaObjectMultiRelations: Set property `modified` to false when loaded from DB

### DIFF
--- a/library/Director/Objects/IcingaObjectMultiRelations.php
+++ b/library/Director/Objects/IcingaObjectMultiRelations.php
@@ -383,6 +383,8 @@ class IcingaObjectMultiRelations implements Iterator, Countable, IcingaConfigRen
         foreach ($this->relations as $k => $v) {
             $this->stored[$k] = clone($v);
         }
+
+        $this->modified = false;
     }
 
     protected function getRelatedClassName()


### PR DESCRIPTION
fixes #2882