### PR TITLE
Fix typo in SNMP Data Fields example documentation

### DIFF
--- a/doc/16-Fields-example-SNMP.md
+++ b/doc/16-Fields-example-SNMP.md
@@ -94,7 +94,7 @@ slightly to fit ITL Commands in case you're using those (snmpv3_*_type VS _alg).
 Your Cisco Health checks assigned to all:
 
 * routers or switches
-* manifactured by Cisco
+* manufactured by Cisco
 * with SNMP credentials, regardless of which version
 
 ...might then look as follows:


### PR DESCRIPTION
Hi,

I was reading the Icinga Director documentation and spotted a typo in the [Data Fields example: SNMP](https://icinga.com/docs/icinga-director/latest/doc/16-Fields-example-SNMP/) page. I've included a patch to fix the typo.

Thanks!