### PR TITLE
Fix service set member count while on director branch

### DIFF
--- a/library/Director/Web/Table/ObjectSetTable.php
+++ b/library/Director/Web/Table/ObjectSetTable.php
@@ -153,12 +153,12 @@ class ObjectSetTable extends ZfQueryBasedTable
                 ['bo' => "branched_icinga_{$type}"],
                 "bo.{$type}_set = bos.object_name",
                 []
-            )->group(['bo.object_name', 'o.object_name']);
+            );
             $query->joinLeft(
                 ['bo' => "branched_icinga_{$type}"],
                 "bo.{$type}_set = bos.object_name",
                 []
-            )->group(['bo.object_name', 'o.object_name']);
+            );
             $this->queries = [
                 $query,
                 $right


### PR DESCRIPTION
While on director branch the service set member count is always displayed as 1 instead of actual count.

Before:
<img width="1120" alt="Screenshot 2024-12-09 at 18 21 25" src="https://github.com/user-attachments/assets/c2d62e9c-380e-486d-b3fa-ca96bb47fbcc">

After:
<img width="1120" alt="Screenshot 2024-12-09 at 18 23 53" src="https://github.com/user-attachments/assets/d03680aa-b8a2-48a0-9d66-c8279461638e">
