### PR TITLE
#2885 Fix MySQL8.4 nonstandard foreign keys deprecation

### DIFF
--- a/schema/mysql-migrations/upgrade_188.sql
+++ b/schema/mysql-migrations/upgrade_188.sql
@@ -1,0 +1,17 @@
+ALTER TABLE director_activity_log
+DROP INDEX checksum,
+ADD UNIQUE INDEX checksum (checksum);
+
+ALTER TABLE director_generated_config
+DROP FOREIGN KEY director_generated_config_activity;
+
+ALTER TABLE director_generated_config
+ADD CONSTRAINT director_generated_config_activity
+    FOREIGN KEY (last_activity_checksum)
+    REFERENCES director_activity_log (checksum)
+    ON DELETE RESTRICT
+    ON UPDATE RESTRICT;
+
+INSERT INTO director_schema_migration
+  (schema_version, migration_time)
+  VALUES (188, NOW());

--- a/schema/mysql.sql
+++ b/schema/mysql.sql
@@ -46,7 +46,7 @@ CREATE TABLE director_activity_log (
   INDEX search_idx (object_name),
   INDEX search_idx2 (object_type(32), object_name(64), change_time),
   INDEX search_author (author),
-  INDEX checksum (checksum)
+  UNIQUE INDEX checksum (checksum)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE director_activity_log_remark (
@@ -114,7 +114,7 @@ CREATE TABLE director_generated_config (
   last_activity_checksum VARBINARY(20) NOT NULL,
   PRIMARY KEY (checksum),
   CONSTRAINT director_generated_config_activity
-    FOREIGN KEY activity_checksum (last_activity_checksum)
+    FOREIGN KEY (last_activity_checksum)
     REFERENCES director_activity_log (checksum)
     ON DELETE RESTRICT
     ON UPDATE RESTRICT
@@ -2446,4 +2446,4 @@ CREATE TABLE branched_icinga_dependency (
 
 INSERT INTO director_schema_migration
   (schema_version, migration_time)
-  VALUES (187, NOW());
+  VALUES (188, NOW());


### PR DESCRIPTION
 - See https://github.com/Icinga/icingaweb2-module-director/issues/2885 (and my comment on the issue).
 - Fix MySQL-8.4 nonstandard foreign keys deprecation.
 
> [!IMPORTANT]  
> I have no previous MySQL experience. This is working queries I generated with the help of AI, and tested locally that it works for my setup using the latest latest MySQL (version 8.4.3) while setting up the Director module on Icinga Web 2 for the first time. Someone with more experience in MySQL should review it, and ideally merge a fix ASAP because it leads to a broken setup for new users (and whoever upgrades MySQL to 8.4+) with a essentially useless SQL error message for a user, which I found no reference to when searching the documentation or online.

The main error the user would normally see looks something like:
```
Migration 0 failed (SQLSTATE[HY000]: General error: 6125 Failed to add the foreign key constraint. Missing unique key for constraint 'director_generated_config_activity' 'director_generated_config_activity' in the referenced table 'director_activity_log'...
```
![director-error-messages](https://github.com/user-attachments/assets/e79f9544-ff6b-42a3-8b1e-3d49eacc2f7e)

