### PR TITLE
Fix fields shoud not be added if empty refs #2945

### DIFF
--- a/library/Director/Data/Exporter.php
+++ b/library/Director/Data/Exporter.php
@@ -296,7 +296,10 @@ class Exporter
     {
         $props = (array) $object->toPlainObject($this->resolveObjects, !$this->showDefaults);
         if ($object->supportsFields()) {
-            $props['fields'] = $this->fieldReferenceLoader->loadFor($object);
+            $fields = $this->fieldReferenceLoader->loadFor($object);
+            if (count($fields) > 0) {
+                $props['fields'] = $fields;
+            }
         }
 
         return $props;


### PR DESCRIPTION
This is properly not the best fix but since a host is basically the same objecttype as a hosttemplate and a host template has fields but a host has not this is the best I could come up with.

Best Regards
Nicolas