### PR TITLE
Disable autocomplete on hidden fields refs #2347

### DIFF
--- a/application/views/helpers/FormStoredPassword.php
+++ b/application/views/helpers/FormStoredPassword.php
@@ -28,6 +28,7 @@ class Zend_View_Helper_FormStoredPassword extends Zend_View_Helper_FormElement
             'type' => 'password',
             'name' => "{$name}[_value]",
             'id'   => $id,
+            'autocomplete' => 'new-password'
         ]);
         $res->add($el);
 


### PR DESCRIPTION
It is a bad idea to let chrome store passwords but since some of us do that, there should not be any autocomplete on hidden fields in any director custom var field.

Best Regards 
Nicolas