### PR TITLE
DeployFormsBug7530: Do not pass null values to `strlen`

### DIFF
--- a/application/forms/DeployFormsBug7530.php
+++ b/application/forms/DeployFormsBug7530.php
@@ -13,7 +13,7 @@ trait DeployFormsBug7530
         if (parent::hasBeenSubmitted()) {
             return true;
         } else {
-            return \strlen($this->getSentValue('confirm_7530')) > 0;
+            return strlen($this->getSentValue('confirm_7530', '')) > 0;
         }
     }
 


### PR DESCRIPTION
Since PHP 8.0 passing of null to strlen is deprecated and hence must be avoided.