### PR TITLE
Fix removal of zones via kickstart

### DIFF
--- a/library/Director/KickstartHelper.php
+++ b/library/Director/KickstartHelper.php
@@ -289,7 +289,7 @@ class KickstartHelper
      */
     protected function removeZones()
     {
-        return $this->removeObjects($this->removeEndpoints, 'External Zone');
+        return $this->removeObjects($this->removeZones, 'External Zone');
     }
 
     /**


### PR DESCRIPTION
I think there was a copy-paste mistake during the implementation, else the `removeZones` variable is never used.

During my quick tests this also fixed https://github.com/Icinga/icingaweb2-module-director/issues/2459.