### PR TITLE
Re-establish membership link with user on restoring deleted usergroup using assign filters

### DIFF
--- a/application/controllers/SuggestController.php
+++ b/application/controllers/SuggestController.php
@@ -2,6 +2,7 @@
 
 namespace Icinga\Module\Director\Controllers;
 
+use Icinga\Module\Director\Objects\IcingaUser;
 use Icinga\Module\Director\Restriction\HostgroupRestriction;
 use ipl\Html\Html;
 use Icinga\Exception\NotFoundError;
@@ -264,6 +265,14 @@ class SuggestController extends ActionController
         ]);
     }
 
+    protected function suggestUserFilterColumns()
+    {
+        return $this->getFilterColumns('user.', [
+            $this->translate('User properties'),
+            $this->translate('Custom variables')
+        ]);
+    }
+
     protected function suggestDataListValuesForListId($id)
     {
         $db = $this->db()->getDbAdapter();
@@ -336,6 +345,8 @@ class SuggestController extends ActionController
     {
         if ($prefix === 'host.') {
             $all = IcingaHost::enumProperties($this->db(), $prefix);
+        } elseif ($prefix === 'user.') {
+            $all = IcingaUser::enumProperties($this->db(), $prefix);
         } else {
             $all = IcingaService::enumProperties($this->db(), $prefix);
         }

--- a/application/controllers/UsergroupController.php
+++ b/application/controllers/UsergroupController.php
@@ -2,8 +2,55 @@
 
 namespace Icinga\Module\Director\Controllers;
 
+use gipfl\Web\Widget\Hint;
+use Icinga\Module\Director\Forms\IcingaDeleteUsergroupForm;
 use Icinga\Module\Director\Web\Controller\ObjectController;
+use Icinga\Web\Notification;
+use ipl\Web\Url;
 
 class UsergroupController extends ObjectController
 {
+    public function deleteAction(): void
+    {
+        $this->addTitle($this->translate('Delete Usergroup'));
+
+        $directMemberQuery = $this->db()
+            ->select()
+            ->from('icinga_usergroup_user')
+            ->where('usergroup_id', $this->object->get('id'));
+
+        $appliedMemberQuery = $this->db()
+            ->select()
+            ->from('icinga_usergroup_user_resolved')
+            ->where('usergroup_id', $this->object->get('id'));
+
+        if ($this->db()->count($directMemberQuery) > 0 || $this->db()->count($appliedMemberQuery) > 0) {
+            $this->content()->add(
+                Hint::info(sprintf(
+                    $this->translate('The usergroup "%s" has members. Do you still want to delete it?'),
+                    $this->object->getObjectName()
+                ))
+            );
+        } else {
+            $this->content()->add(
+                Hint::info(sprintf(
+                    $this->translate('The usergroup "%s" does not have any members. You can go ahead and delete it.'),
+                    $this->object->getObjectName()
+                ))
+            );
+        }
+
+        $this->content()->add(
+            (new IcingaDeleteUsergroupForm($this->object, $this->db(), $this->branch))
+                ->on(IcingaDeleteUsergroupForm::ON_SUBMIT, function () {
+                    Notification::success(sprintf(
+                        $this->translate('User group %s has been deleted.'),
+                        $this->object->getObjectName()
+                    ));
+
+                    $this->redirectNow(Url::fromPath('director/usergroups'));
+                })
+                ->handleRequest($this->getServerRequest())
+        );
+    }
 }

--- a/application/forms/IcingaDeleteUsergroupForm.php
+++ b/application/forms/IcingaDeleteUsergroupForm.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Icinga\Module\Director\Forms;
+
+use Icinga\Module\Director\Data\Db\DbObjectStore;
+use Icinga\Module\Director\Db;
+use Icinga\Module\Director\Db\Branch\Branch;
+use Icinga\Module\Director\Objects\IcingaObject;
+use Icinga\Web\Session;
+use ipl\Web\Common\CsrfCounterMeasure;
+use ipl\Web\Compat\CompatForm;
+
+class IcingaDeleteUsergroupForm extends CompatForm
+{
+    use CsrfCounterMeasure;
+
+    public function __construct(
+        protected IcingaObject $object,
+        protected Db $db,
+        protected ?Branch $branch = null
+    ) {
+    }
+
+    protected function assemble(): void
+    {
+        $this->addElement($this->createCsrfCounterMeasure(Session::getSession()->getId()));
+
+        $this->addElement('submit', 'submit', [
+            'label' => $this->translate('Delete')
+        ]);
+    }
+
+    protected function onSuccess(): void
+    {
+        (new DbObjectStore($this->db, $this->branch))->delete($this->object);
+    }
+}

--- a/application/forms/IcingaServiceForm.php
+++ b/application/forms/IcingaServiceForm.php
@@ -17,6 +17,7 @@ use Icinga\Module\Director\Objects\IcingaServiceSet;
 use Icinga\Module\Director\Web\Table\ObjectsTableHost;
 use ipl\Html\Html;
 use gipfl\IcingaWeb2\Link;
+use ipl\Html\HtmlElement;
 use RuntimeException;
 
 class IcingaServiceForm extends DirectorObjectForm
@@ -725,6 +726,15 @@ class IcingaServiceForm extends DirectorObjectForm
             ));
         }
 
+        $applied = $this->getAppliedGroups();
+        if (! empty($applied)) {
+            $this->addElement('simpleNote', 'applied_groups', [
+                'label'  => $this->translate('Applied groups'),
+                'value'  => $this->createServicegroupLinks($applied),
+                'ignore' => true,
+            ]);
+        }
+
         return $this;
     }
 
@@ -866,5 +876,47 @@ class IcingaServiceForm extends DirectorObjectForm
                 $this->object->set('object_name', end($imports));
             }
         }
+    }
+
+    /**
+     * Create links to applied servicegroups.
+     *
+     * @param $groups
+     *
+     * @return HtmlElement
+     */
+    protected function createServicegroupLinks($groups): HtmlElement
+    {
+        $links = [];
+        foreach ($groups as $name) {
+            if (! empty($links)) {
+                $links[] = ', ';
+            }
+            $links[] = Link::create(
+                $name,
+                'director/servicegroup',
+                ['name' => $name],
+                ['data-base-target' => '_next']
+            );
+        }
+
+        return Html::tag('span', ['class' => 'host-group-links'], $links);
+    }
+
+    /**
+     * Get applied servicegroups.
+     *
+     * @return array
+     */
+    protected function getAppliedGroups(): array
+    {
+        if ($this->isNew()) {
+            return [];
+        }
+
+        /** @var IcingaService $object */
+        $object = $this->object();
+
+        return $object->getAppliedGroups();
     }
 }

--- a/application/forms/IcingaUserForm.php
+++ b/application/forms/IcingaUserForm.php
@@ -2,7 +2,11 @@
 
 namespace Icinga\Module\Director\Forms;
 
+use gipfl\IcingaWeb2\Link;
+use Icinga\Module\Director\Objects\IcingaUser;
 use Icinga\Module\Director\Web\Form\DirectorObjectForm;
+use ipl\Html\Html;
+use ipl\Html\HtmlElement;
 
 class IcingaUserForm extends DirectorObjectForm
 {
@@ -116,6 +120,15 @@ class IcingaUserForm extends DirectorObjectForm
             )
         ));
 
+        $applied = $this->getAppliedGroups();
+        if (! empty($applied)) {
+            $this->addElement('simpleNote', 'applied_groups', [
+                'label'  => $this->translate('Applied groups'),
+                'value'  => $this->createUsergroupLinks($applied),
+                'ignore' => true,
+            ]);
+        }
+
         return $this;
     }
 
@@ -210,5 +223,47 @@ class IcingaUserForm extends DirectorObjectForm
         )->where('object_type = ?', 'object')->order('display');
 
         return $db->fetchPairs($select);
+    }
+
+    /**
+     * Get applied user groups
+     *
+     * @return array
+     */
+    protected function getAppliedGroups(): array
+    {
+        if ($this->isNew()) {
+            return [];
+        }
+
+        /** @var IcingaUser $object */
+        $object = $this->object();
+
+        return $object->getAppliedGroups();
+    }
+
+    /**
+     * Create links for applied user groups
+     *
+     * @param $groups
+     *
+     * @return HtmlElement
+     */
+    protected function createUsergroupLinks($groups): HtmlElement
+    {
+        $links = [];
+        foreach ($groups as $name) {
+            if (! empty($links)) {
+                $links[] = ', ';
+            }
+            $links[] = Link::create(
+                $name,
+                'director/usergroup',
+                ['name' => $name],
+                ['data-base-target' => '_next']
+            );
+        }
+
+        return Html::tag('span', ['class' => 'user-group-links'], $links);
     }
 }

--- a/application/forms/IcingaUserGroupForm.php
+++ b/application/forms/IcingaUserGroupForm.php
@@ -3,6 +3,7 @@
 namespace Icinga\Module\Director\Forms;
 
 use Icinga\Module\Director\Web\Form\DirectorObjectForm;
+use ipl\Web\Url;
 
 class IcingaUserGroupForm extends DirectorObjectForm
 {
@@ -20,6 +21,7 @@ class IcingaUserGroupForm extends DirectorObjectForm
         ));
 
         $this->addGroupDisplayNameElement()
+             ->addAssignmentElements()
              ->addZoneElements()
              ->groupMainProperties()
              ->setButtons();
@@ -43,5 +45,12 @@ class IcingaUserGroupForm extends DirectorObjectForm
         ]);
 
         return $this;
+    }
+
+    protected function deleteObject($object): void
+    {
+        $this->redirectAndExit(
+            Url::fromPath('director/usergroup/delete', ['uuid' => $object->getUniqueId()->toString()])
+        );
     }
 }

--- a/application/forms/IcingaUserGroupForm.php
+++ b/application/forms/IcingaUserGroupForm.php
@@ -47,7 +47,24 @@ class IcingaUserGroupForm extends DirectorObjectForm
         return $this;
     }
 
-    protected function deleteObject($object): void
+    protected function addAssignmentElements()
+    {
+        $this->addAssignFilter([
+            'suggestionContext' => 'UserFilterColumns',
+            'required' => false,
+            'description' => $this->translate(
+                'This allows you to configure an assignment filter. Please feel'
+                . ' free to combine as many nested operators as you want. The'
+                . ' "contains" operator is valid for arrays only. Please use'
+                . ' wildcards and the = (equals) operator when searching for'
+                . ' partial string matches, like in *.example.com'
+            )
+        ]);
+
+        return $this;
+    }
+
+    protected function deleteObject($object)
     {
         $this->redirectAndExit(
             Url::fromPath('director/usergroup/delete', ['uuid' => $object->getUniqueId()->toString()])

--- a/library/Director/Data/PropertiesFilter.php
+++ b/library/Director/Data/PropertiesFilter.php
@@ -8,6 +8,8 @@ class PropertiesFilter
     public static $HOST_PROPERTY = 'HOST_PROPERTY';
     public static $SERVICE_PROPERTY = 'SERVICE_PROPERTY';
 
+    public static $USER_PROPERTY = 'USER_PROPERTY';
+
     protected $blacklist = array(
         'id',
         'object_name',

--- a/library/Director/Db.php
+++ b/library/Director/Db.php
@@ -718,6 +718,31 @@ class Db extends DbConnection
         return $this->db()->fetchAll($select);
     }
 
+    /**
+     * Fetch all distinct user vars.
+     *
+     * @return ?array
+     */
+    public function fetchDistinctUserVars()
+    {
+        $select = $this->db()->select()->distinct()->from(
+            array('u' => 'icinga_user_var'),
+            array(
+                'varname'  => 'u.varname',
+                'format'   => 'u.format',
+                'caption'  => 'df.caption',
+                'datatype' => 'df.datatype'
+            )
+        )->joinLeft(
+            array('df' => 'director_datafield'),
+            'df.varname = u.varname',
+            array()
+        )->order('varname');
+
+        return $this->db()->fetchAll($select);
+    }
+
+
     public function dbHexFunc($column)
     {
         if ($this->isPgsql()) {

--- a/library/Director/Objects/IcingaObject.php
+++ b/library/Director/Objects/IcingaObject.php
@@ -881,9 +881,6 @@ abstract class IcingaObject extends DbObject implements IcingaConfigRenderer
     public function getAppliedGroups()
     {
         $this->assertGroupsSupport();
-        if (! $this instanceof IcingaHost) {
-            throw new RuntimeException('getAppliedGroups is only available for hosts currently!');
-        }
         if (! $this->hasBeenLoadedFromDb()) {
             // There are no stored related/resolved groups. We'll also not resolve
             // them here on demand.

--- a/library/Director/Objects/IcingaUser.php
+++ b/library/Director/Objects/IcingaUser.php
@@ -2,6 +2,8 @@
 
 namespace Icinga\Module\Director\Objects;
 
+use Icinga\Data\Db\DbConnection;
+use Icinga\Module\Director\Data\PropertiesFilter;
 use Icinga\Module\Director\Db;
 use Icinga\Module\Director\DirectorObject\Automation\ExportInterface;
 use Icinga\Module\Director\Exception\DuplicateKeyException;
@@ -51,5 +53,84 @@ class IcingaUser extends IcingaObject implements ExportInterface
     public function getUniqueIdentifier()
     {
         return $this->getObjectName();
+    }
+
+    /**
+     * Enumerate properties for user objects
+     *
+     * @param ?DbConnection $connection
+     * @param $prefix
+     * @param $filter
+     *
+     * @return array
+     */
+    public static function enumProperties(DbConnection $connection = null, $prefix = '', $filter = null): array
+    {
+        $userProperties = array();
+        if ($filter === null) {
+            $filter = new PropertiesFilter();
+        }
+
+        $realProperties = array_merge(['templates'], static::create()->listProperties());
+        sort($realProperties);
+
+        if ($filter->match(PropertiesFilter::$USER_PROPERTY, 'name')) {
+            $userProperties[$prefix . 'name'] = 'name';
+        }
+
+        foreach ($realProperties as $prop) {
+            if (!$filter->match(PropertiesFilter::$USER_PROPERTY, $prop)) {
+                continue;
+            }
+
+            if (substr($prop, -3) === '_id') {
+                if ($prop === 'template_choice_id') {
+                    continue;
+                }
+                $prop = substr($prop, 0, -3);
+            }
+
+            $userProperties[$prefix . $prop] = $prop;
+        }
+
+        unset($userProperties[$prefix . 'uuid']);
+        unset($userProperties[$prefix . 'custom_endpoint_name']);
+
+        $userVars = [];
+
+        if ($connection instanceof Db) {
+            foreach ($connection->fetchDistinctUserVars() as $var) {
+                if ($filter->match(PropertiesFilter::$CUSTOM_PROPERTY, $var->varname, $var)) {
+                    if ($var->datatype) {
+                        $userVars[$prefix . 'vars.' . $var->varname] = sprintf(
+                            '%s (%s)',
+                            $var->varname,
+                            $var->caption
+                        );
+                    } else {
+                        $userVars[$prefix . 'vars.' . $var->varname] = $var->varname;
+                    }
+                }
+            }
+        }
+
+        //$properties['vars.*'] = 'Other custom variable';
+        ksort($userVars);
+
+
+        $props = mt('director', 'User properties');
+        $vars  = mt('director', 'Custom variables');
+
+        $properties = [];
+        if (! empty($userProperties)) {
+            $properties[$props] = $userProperties;
+            $properties[$props][$prefix . 'groups'] = 'Groups';
+        }
+
+        if (! empty($userVars)) {
+            $properties[$vars] = $userVars;
+        }
+
+        return $properties;
     }
 }

--- a/library/Director/Objects/IcingaUser.php
+++ b/library/Director/Objects/IcingaUser.php
@@ -50,9 +50,32 @@ class IcingaUser extends IcingaObject implements ExportInterface
         'zone'   => 'IcingaZone',
     );
 
+    /** @var ?UserGroupMembershipResolver Resolver for user group memberships */
+    protected $usergroupMembershipResolver;
+
     public function getUniqueIdentifier()
     {
         return $this->getObjectName();
+    }
+
+    protected function getUserGroupMembershipResolver()
+    {
+        if (! $this->usergroupMembershipResolver) {
+            $this->usergroupMembershipResolver = new UserGroupMembershipResolver(
+                $this->getConnection()
+            );
+        }
+
+        return $this->usergroupMembershipResolver;
+    }
+
+    protected function notifyResolvers()
+    {
+        $resolver = $this->getUserGroupMembershipResolver();
+        $resolver->addObject($this);
+        $resolver->refreshDb();
+
+        return $this;
     }
 
     /**

--- a/library/Director/Objects/IcingaUser.php
+++ b/library/Director/Objects/IcingaUser.php
@@ -82,13 +82,16 @@ class IcingaUser extends IcingaObject implements ExportInterface
      * Enumerate properties for user objects
      *
      * @param ?DbConnection $connection
-     * @param $prefix
-     * @param $filter
+     * @param string $prefix
+     * @param ?PropertiesFilter $filter
      *
      * @return array
      */
-    public static function enumProperties(DbConnection $connection = null, $prefix = '', $filter = null): array
-    {
+    public static function enumProperties(
+        ?DbConnection $connection = null,
+        string $prefix = '',
+        ?PropertiesFilter $filter = null
+    ): array {
         $userProperties = array();
         if ($filter === null) {
             $filter = new PropertiesFilter();
@@ -102,7 +105,7 @@ class IcingaUser extends IcingaObject implements ExportInterface
         }
 
         foreach ($realProperties as $prop) {
-            if (!$filter->match(PropertiesFilter::$USER_PROPERTY, $prop)) {
+            if (! $filter->match(PropertiesFilter::$USER_PROPERTY, $prop)) {
                 continue;
             }
 

--- a/library/Director/Objects/IcingaUserGroup.php
+++ b/library/Director/Objects/IcingaUserGroup.php
@@ -8,6 +8,9 @@ class IcingaUserGroup extends IcingaObjectGroup
 
     protected $uuidColumn = 'uuid';
 
+    /** @var UserGroupMembershipResolver */
+    protected $userGroupMembershipResolver;
+
     protected $defaultProperties = [
         'id'            => null,
         'uuid'          => null,
@@ -16,6 +19,7 @@ class IcingaUserGroup extends IcingaObjectGroup
         'disabled'      => 'n',
         'display_name'  => null,
         'zone_id'       => null,
+        'assign_filter' => null
     ];
 
     protected $relations = [
@@ -25,5 +29,40 @@ class IcingaUserGroup extends IcingaObjectGroup
     protected function prefersGlobalZone()
     {
         return false;
+    }
+
+    public function supportsAssignments(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Set the membership resolver for the user group.
+     *
+     * @param UserGroupMembershipResolver $resolver
+     *
+     * @return $this
+     */
+    public function setUserGroupMembershipResolver(UserGroupMembershipResolver $resolver): static
+    {
+        $this->userGroupMembershipResolver = $resolver;
+
+        return $this;
+    }
+
+    /**
+     * Get the membership resolver for the user group.
+     *
+     * @return UserGroupMembershipResolver
+     */
+    protected function getMemberShipResolver(): UserGroupMembershipResolver
+    {
+        if ($this->userGroupMembershipResolver === null) {
+            $this->userGroupMembershipResolver = new UserGroupMembershipResolver(
+                $this->getConnection()
+            );
+        }
+
+        return $this->userGroupMembershipResolver;
     }
 }

--- a/library/Director/Objects/UserGroupMembershipResolver.php
+++ b/library/Director/Objects/UserGroupMembershipResolver.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Icinga\Module\Director\Objects;
+
+class UserGroupMembershipResolver extends GroupMembershipResolver
+{
+    protected $type = 'user';
+}

--- a/schema/mysql-migrations/upgrade_192.sql
+++ b/schema/mysql-migrations/upgrade_192.sql
@@ -1,0 +1,22 @@
+CREATE TABLE icinga_usergroup_user_resolved
+(
+  usergroup_id INT(10) UNSIGNED NOT NULL,
+  user_id      INT(10) UNSIGNED NOT NULL,
+  PRIMARY KEY (usergroup_id, user_id),
+  CONSTRAINT icinga_usergroup_user_resolved_user
+    FOREIGN KEY user (user_id)
+      REFERENCES icinga_user (id)
+      ON DELETE CASCADE
+      ON UPDATE CASCADE,
+  CONSTRAINT icinga_usergroup_user_resolved_usergroup
+    FOREIGN KEY usergroup (usergroup_id)
+      REFERENCES icinga_usergroup (id)
+      ON DELETE CASCADE
+      ON UPDATE CASCADE
+) ENGINE = InnoDB DEFAULT CHARSET = utf8;
+
+ALTER TABLE icinga_usergroup ADD COLUMN assign_filter TEXT DEFAULT NULL;
+
+INSERT INTO director_schema_migration
+(schema_version, migration_time)
+VALUES (192, NOW());

--- a/schema/mysql.sql
+++ b/schema/mysql.sql
@@ -1186,6 +1186,7 @@ CREATE TABLE icinga_usergroup (
   disabled ENUM('y', 'n') NOT NULL DEFAULT 'n',
   display_name VARCHAR(255) DEFAULT NULL,
   zone_id INT(10) UNSIGNED DEFAULT NULL,
+  assign_filter TEXT DEFAULT NULL,
   PRIMARY KEY (id),
   UNIQUE INDEX uuid (uuid),
   UNIQUE INDEX object_name (object_name),
@@ -2446,6 +2447,23 @@ CREATE TABLE branched_icinga_dependency (
     ON UPDATE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
+CREATE TABLE icinga_usergroup_user_resolved
+(
+  usergroup_id INT(10) UNSIGNED NOT NULL,
+  user_id      INT(10) UNSIGNED NOT NULL,
+  PRIMARY KEY (usergroup_id, user_id),
+  CONSTRAINT icinga_usergroup_user_resolved_user
+    FOREIGN KEY user (user_id)
+      REFERENCES icinga_user (id)
+      ON DELETE CASCADE
+      ON UPDATE CASCADE,
+  CONSTRAINT icinga_usergroup_user_resolved_usergroup
+    FOREIGN KEY usergroup (usergroup_id)
+      REFERENCES icinga_usergroup (id)
+      ON DELETE CASCADE
+      ON UPDATE CASCADE
+) ENGINE = InnoDB DEFAULT CHARSET = utf8;
+
 INSERT INTO director_schema_migration
   (schema_version, migration_time)
-  VALUES (191, NOW());
+  VALUES (192, NOW());

--- a/schema/pgsql-migrations/upgrade_192.sql
+++ b/schema/pgsql-migrations/upgrade_192.sql
@@ -1,0 +1,25 @@
+CREATE TABLE icinga_usergroup_user_resolved
+(
+  usergroup_id integer NOT NULL,
+  user_id      integer NOT NULL,
+  PRIMARY KEY (usergroup_id, user_id),
+  CONSTRAINT icinga_usergroup_user_resolved_user
+    FOREIGN KEY (user_id)
+      REFERENCES icinga_user (id)
+      ON DELETE CASCADE
+      ON UPDATE CASCADE,
+  CONSTRAINT icinga_usergroup_user_resolved_usergroup
+    FOREIGN KEY (usergroup_id)
+      REFERENCES icinga_usergroup (id)
+      ON DELETE CASCADE
+      ON UPDATE CASCADE
+);
+
+CREATE INDEX usergroup_user_resolved_user ON icinga_usergroup_user_resolved (user_id);
+CREATE INDEX usergroup_user_resolved_usergroup ON icinga_usergroup_user_resolved (usergroup_id);
+
+ALTER TABLE icinga_usergroup ADD COLUMN assign_filter text DEFAULT NULL;
+
+INSERT INTO director_schema_migration
+  (schema_version, migration_time)
+  VALUES (192, NOW());

--- a/schema/pgsql.sql
+++ b/schema/pgsql.sql
@@ -1415,6 +1415,7 @@ CREATE TABLE icinga_usergroup (
   disabled enum_boolean NOT NULL DEFAULT 'n',
   display_name character varying(255) DEFAULT NULL,
   zone_id integer DEFAULT NULL,
+  assign_filter text DEFAULT NULL,
   PRIMARY KEY (id),
   CONSTRAINT icinga_usergroup_zone
     FOREIGN KEY (zone_id)
@@ -2780,7 +2781,26 @@ CREATE TABLE branched_icinga_dependency (
 CREATE UNIQUE INDEX dependency_branch_object_name ON branched_icinga_dependency (branch_uuid, object_name);
 CREATE INDEX branched_dependency_search_object_name ON branched_icinga_dependency (object_name);
 
+CREATE TABLE icinga_usergroup_user_resolved
+(
+  usergroup_id integer NOT NULL,
+  user_id      integer NOT NULL,
+  PRIMARY KEY (usergroup_id, user_id),
+  CONSTRAINT icinga_usergroup_user_resolved_user
+    FOREIGN KEY (user_id)
+      REFERENCES icinga_user (id)
+      ON DELETE CASCADE
+      ON UPDATE CASCADE,
+  CONSTRAINT icinga_usergroup_user_resolved_usergroup
+    FOREIGN KEY (usergroup_id)
+      REFERENCES icinga_usergroup (id)
+      ON DELETE CASCADE
+      ON UPDATE CASCADE
+);
+
+CREATE INDEX usergroup_user_resolved_user ON icinga_usergroup_user_resolved (user_id);
+CREATE INDEX usergroup_user_resolved_usergroup ON icinga_usergroup_user_resolved (usergroup_id);
 
 INSERT INTO director_schema_migration
   (schema_version, migration_time)
-  VALUES (190, NOW());
+  VALUES (192, NOW());


### PR DESCRIPTION
With this PR:

- A confirmation page is opened while deleting the group to prevent deleting the user groups by mistake
- And an assign filter has been added to the user group configuration. When a user group is configured with an assign filter, the membership link is established with the users that matches the filter. And when such a user group is deleted and restored the membership links are also restored based on the configured filter.

fixes #2914