### PR TITLE
Add username to Deployment details page

### DIFF
--- a/library/Director/Core/CoreApi.php
+++ b/library/Director/Core/CoreApi.php
@@ -835,7 +835,7 @@ constants
         if ($packageName === null) {
             $packageName = $db->settings()->get('icinga_package_name');
         }
-        $username = '';
+        $username = null;
         $auth = Auth::getInstance();
         if ($auth->isAuthenticated()) {
             $username = $auth->getUser()->getUsername();

--- a/library/Director/Core/CoreApi.php
+++ b/library/Director/Core/CoreApi.php
@@ -3,6 +3,7 @@
 namespace Icinga\Module\Director\Core;
 
 use Exception;
+use Icinga\Authentication\Auth;
 use Icinga\Exception\NotFoundError;
 use Icinga\Module\Director\Db;
 use Icinga\Module\Director\Hook\DeploymentHook;
@@ -834,6 +835,11 @@ constants
         if ($packageName === null) {
             $packageName = $db->settings()->get('icinga_package_name');
         }
+        $username = '';
+        $auth = Auth::getInstance();
+        if ($auth->isAuthenticated()) {
+            $username = $auth->getUser()->getUsername();
+        }
         $start = microtime(true);
         /** @var DirectorDeploymentLog $deployment */
         $deployment = DirectorDeploymentLog::create(array(
@@ -842,9 +848,9 @@ constants
             'peer_identity'   => $this->client->getPeerIdentity(),
             'start_time'      => date('Y-m-d H:i:s'),
             'config_checksum' => $config->getChecksum(),
-            'last_activity_checksum' => $config->getLastActivityChecksum()
+            'last_activity_checksum' => $config->getLastActivityChecksum(),
+            'username'        => $username
             // 'triggered_by'   => Util::getUsername(),
-            // 'username'       => Util::getUsername(),
             // 'module_name'    => $moduleName,
         ));
 

--- a/library/Director/Web/Widget/DeploymentInfo.php
+++ b/library/Director/Web/Widget/DeploymentInfo.php
@@ -78,6 +78,7 @@ class DeploymentInfo extends HtmlDocument
         $table->addNameValuePairs([
             $this->translate('Deployment time') => $dep->start_time,
             $this->translate('Sent to')         => $dep->peer_identity,
+            $this->translate('Triggered by')    => $dep->username,
         ]);
         if ($this->config !== null) {
             $table->addNameValuePairs([


### PR DESCRIPTION
Hello,

This PR enables Director to store username of a user who has initiated a deployment and to display it on the Deployment details page.

<img width="544" alt="SCR-20250626-nmsw-2" src="https://github.com/user-attachments/assets/3d818a0e-69de-4580-9778-d90b98f749f5" />

Resolves issue #1364