### PR TITLE
MYSQL: Update columns storing large strings to MEDIUMTEXT

### DIFF
--- a/schema/mysql-migrations/upgrade_191.sql
+++ b/schema/mysql-migrations/upgrade_191.sql
@@ -2,6 +2,9 @@ ALTER TABLE director_activity_log
   MODIFY COLUMN old_properties MEDIUMTEXT DEFAULT NULL COMMENT 'Property hash, JSON',
   MODIFY COLUMN new_properties MEDIUMTEXT DEFAULT NULL COMMENT 'Property hash, JSON';
 
+ALTER TABLE icinga_host_var
+  MODIFY COLUMN varvalue MEDIUMTEXT DEFAULT NULL;
+
 INSERT INTO director_schema_migration
 (schema_version, migration_time)
 VALUES (191, NOW());

--- a/schema/mysql.sql
+++ b/schema/mysql.sql
@@ -654,7 +654,7 @@ CREATE TABLE icinga_host_field (
 CREATE TABLE icinga_host_var (
   host_id INT(10) UNSIGNED NOT NULL,
   varname VARCHAR(255) NOT NULL COLLATE utf8_bin,
-  varvalue TEXT DEFAULT NULL,
+  varvalue MEDIUMTEXT DEFAULT NULL,
   format enum ('string', 'json', 'expression'), -- immer string vorerst
   checksum VARBINARY(20) DEFAULT NULL,
   PRIMARY KEY (host_id, varname),


### PR DESCRIPTION
**Problem:**
For complex network device configuration with very large interfaces, the automation fails with the following error in MySQL as the custom variable storing the interface configuration will be very large:
```
Exception while syncing Icinga\Module\Director\Objects\IcingaHost XXX: Storing director_activity_log[] failed: SQLSTATE[22001]: String data, right truncated: 1406 Data too long for column 'new_properties' at row 1
```
**Solution:**
MySQL:

1. Change the data type of `old_properties` and `new_properties` column in `director_activity_log` table to `MEDIUMTEXT`
2. Change the data type of `varvalue`  column in `icinga_host_var` table to `MEDIUMTEXT`

PostgreSQL:
No changes required as the data type `text` already allows storing of string up to the size of 1GB.

ref/IP/62246