### PR TITLE
Don't require permissions for custom var rendering hooks

### DIFF
--- a/register-hooks.php
+++ b/register-hooks.php
@@ -73,8 +73,8 @@ if ($this->getConfig()->get('frontend', 'disabled', 'no') !== 'yes') {
     $this->provideHook('cube/IcingaDbActions', IcingaDbCubeLinks::class);
 }
 
-$this->provideHook('Icingadb/CustomVarRenderer', alwaysRun: true);
-$this->provideHook('Monitoring/CustomVarRenderer', alwaysRun: true);
+$this->provideHook('Icingadb/CustomVarRenderer', null, true);
+$this->provideHook('Monitoring/CustomVarRenderer', null, true);
 
 $directorHooks = [
     'director/DataType' => [


### PR DESCRIPTION
Previously, at least general access permissions for the module were required in
order to execute the custom variable rendering hooks. This has been relaxed so
that users who do not have permissions for the Director module at all can now
also benefit from the custom variable rendering hooks, e.g., that Director
labels instead of custom variable names from configuration are displayed.