### PR TITLE
Fix GitHub Actions

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -28,7 +28,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          tools: phpcs
+          tools: phpcs:3
 
       - name: Setup dependencies
         run: composer require -n --no-progress overtrue/phplint phpunit/phpunit


### PR DESCRIPTION
**Don't test PHP < 8.2**

IPL requires PHP 8.2, and it would be impractical to run unit tests for lower PHP versions in GitHub Actions. Although the current Director version still claims to support PHP < 8.2, it is unreasonable to test this, as it is impossible to set up an Icinga Web ecosystem in current versions with PHP < 8.2. However, we will not merge any PRs using PHP 8 features into Director 1.11.

**Lint PHP with phpcs version 3.x**

Pin phpcs to 3.x (current version is 4.x) to avoid having to migrate the deprecated syntax `@condingStandards...` just yet.