### PR TITLE
IcingaObjectHandler: Fix undefined array key 'imports' error

### DIFF
--- a/library/Director/RestApi/IcingaObjectHandler.php
+++ b/library/Director/RestApi/IcingaObjectHandler.php
@@ -148,7 +148,7 @@ class IcingaObjectHandler extends RequestHandler
                         );
                     }
 
-                    if (in_array($object->get('object_name'), $data['imports'])) {
+                    if (isset($data['imports']) && in_array($object->get('object_name'), $data['imports'])) {
                         throw new RuntimeException(
                             'You can not import the same object into itself: ' . $object->getObjectName()
                         );


### PR DESCRIPTION
This was introduced by the commit 0a87527d0773122df53d164f7894a1d8a4855bf1 (https://github.com/Icinga/icingaweb2-module-director/commit/0a87527d0773122df53d164f7894a1d8a4855bf1)