### PR TITLE
Fix `Icinga/zf1` compat

### DIFF
--- a/library/Director/Web/Form/Element/Boolean.php
+++ b/library/Director/Web/Form/Element/Boolean.php
@@ -43,7 +43,7 @@ class Boolean extends ZfSelect
      * @param string $key
      * @codingStandardsIgnoreStart
      */
-    protected function _filterValue(&$value, &$key)
+    protected function _filterValue(&$value, $key)
     {
         // @codingStandardsIgnoreEnd
         if ($value === true) {

--- a/library/Director/Web/Form/Element/DataFilter.php
+++ b/library/Director/Web/Form/Element/DataFilter.php
@@ -56,7 +56,7 @@ class DataFilter extends FormElement
      * @inheritdoc
      * @codingStandardsIgnoreStart
      */
-    protected function _filterValue(&$value, &$key)
+    protected function _filterValue(&$value, $key)
     {
         // @codingStandardsIgnoreEnd
         try {

--- a/library/Director/Web/Form/Element/ExtensibleSet.php
+++ b/library/Director/Web/Form/Element/ExtensibleSet.php
@@ -54,7 +54,7 @@ class ExtensibleSet extends FormElement
     /**
      * @codingStandardsIgnoreStart
      */
-    protected function _filterValue(&$value, &$key)
+    protected function _filterValue(&$value, $key)
     {
         // @codingStandardsIgnoreEnd
         if (is_array($value)) {


### PR DESCRIPTION
The method signature of `Zend_Form_Element::_filterValue()` was changed years ago in `shardj/zf1-future`, but we provided a patch so that Director did not need to be modified to maintain compatibility between multiple library versions. With the upcoming support for PHP 8.5, we no longer need to support older library versions and can adapt Director to be compatible with the changed signature.

refs Icinga/icinga-php-thirdparty#103