### PR TITLE
Adapt to `react/promise` v3 and `react/event-loop` v1.6

### DIFF
--- a/application/clicommands/JobsCommand.php
+++ b/application/clicommands/JobsCommand.php
@@ -10,7 +10,7 @@ use Icinga\Module\Director\Cli\Command;
 use Icinga\Module\Director\Daemon\JsonRpcLogWriter as JsonRpcLogWriterAlias;
 use Icinga\Module\Director\Daemon\Logger;
 use Icinga\Module\Director\Objects\DirectorJob;
-use React\EventLoop\Factory as Loop;
+use React\EventLoop\Loop;
 use React\EventLoop\LoopInterface;
 use React\Stream\ReadableResourceStream;
 use React\Stream\WritableResourceStream;
@@ -20,7 +20,7 @@ class JobsCommand extends Command
     public function runAction()
     {
         $this->app->getModuleManager()->loadEnabledModules();
-        $loop = Loop::create();
+        $loop = Loop::get();
         if ($this->params->get('rpc')) {
             $this->enableRpc($loop);
         }

--- a/library/Director/Daemon/BackgroundDaemon.php
+++ b/library/Director/Daemon/BackgroundDaemon.php
@@ -6,7 +6,7 @@ use Exception;
 use gipfl\Cli\Process;
 use gipfl\IcingaCliDaemon\DbResourceConfigWatch;
 use gipfl\SystemD\NotifySystemD;
-use React\EventLoop\Factory as Loop;
+use React\EventLoop\Loop;
 use React\EventLoop\LoopInterface;
 use Ramsey\Uuid\Uuid;
 
@@ -45,7 +45,7 @@ class BackgroundDaemon
     public function run(?LoopInterface $loop = null)
     {
         if ($ownLoop = ($loop === null)) {
-            $loop = Loop::create();
+            $loop = Loop::get();
         }
         $this->loop = $loop;
         $this->loop->futureTick(function () {

--- a/library/Director/Daemon/DaemonDb.php
+++ b/library/Director/Daemon/DaemonDb.php
@@ -125,7 +125,7 @@ class DaemonDb
     {
         if ($this->connection !== null) {
             Logger::error('Trying to establish a connection while being connected');
-            return reject();
+            return reject(new RuntimeException());
         }
         $callback = function () use ($config) {
             $this->reallyEstablishConnection($config);

--- a/library/Director/Daemon/DaemonDb.php
+++ b/library/Director/Daemon/DaemonDb.php
@@ -112,7 +112,7 @@ class DaemonDb
             $this->emitStatus('no configuration');
             $this->dbConfig = $config;
 
-            return resolve();
+            return resolve(null);
         } else {
             $this->emitStatus('configuration loaded');
             $this->dbConfig = $config;
@@ -243,7 +243,7 @@ class DaemonDb
             }
         }
 
-        return resolve();
+        return resolve(null);
     }
 
     /**
@@ -252,7 +252,7 @@ class DaemonDb
     public function disconnect()
     {
         if (! $this->connection) {
-            return resolve();
+            return resolve(null);
         }
         if ($this->pendingDisconnect) {
             return $this->pendingDisconnect->promise();
@@ -266,7 +266,7 @@ class DaemonDb
             $resolve = function () use ($pendingComponents, $component) {
                 $pendingComponents->detach($component);
                 if ($pendingComponents->count() === 0) {
-                    $this->pendingDisconnect->resolve();
+                    $this->pendingDisconnect->resolve(null);
                 }
             };
             // TODO: What should we do in case they don't?

--- a/library/Director/Daemon/DaemonDb.php
+++ b/library/Director/Daemon/DaemonDb.php
@@ -11,6 +11,7 @@ use Icinga\Module\Director\Db\Migrations;
 use ipl\Stdlib\EventEmitter;
 use React\EventLoop\LoopInterface;
 use React\Promise\Deferred;
+use React\Promise\PromiseInterface;
 use RuntimeException;
 use SplObjectStorage;
 
@@ -219,7 +220,7 @@ class DaemonDb
     }
 
     /**
-     * @return \React\Promise\PromiseInterface
+     * @return PromiseInterface
      */
     protected function reconnect()
     {
@@ -232,7 +233,7 @@ class DaemonDb
     }
 
     /**
-     * @return \React\Promise\ExtendedPromiseInterface
+     * @return PromiseInterface
      */
     public function connect()
     {
@@ -246,7 +247,7 @@ class DaemonDb
     }
 
     /**
-     * @return \React\Promise\ExtendedPromiseInterface
+     * @return PromiseInterface
      */
     public function disconnect()
     {

--- a/library/Director/Daemon/DbBasedComponent.php
+++ b/library/Director/Daemon/DbBasedComponent.php
@@ -3,17 +3,19 @@
 namespace Icinga\Module\Director\Daemon;
 
 use Icinga\Module\Director\Db;
+use React\Promise\PromiseInterface;
 
 interface DbBasedComponent
 {
     /**
      * @param Db $db
-     * @return \React\Promise\ExtendedPromiseInterface;
+     *
+     * @return PromiseInterface;
      */
     public function initDb(Db $db);
 
     /**
-     * @return \React\Promise\ExtendedPromiseInterface;
+     * @return PromiseInterface;
      */
     public function stopDb();
 }

--- a/library/Director/Daemon/DeploymentChecker.php
+++ b/library/Director/Daemon/DeploymentChecker.php
@@ -6,6 +6,7 @@ use Exception;
 use Icinga\Module\Director\Db;
 use Icinga\Module\Director\Objects\DirectorDeploymentLog;
 use React\EventLoop\LoopInterface;
+use React\Promise\PromiseInterface;
 
 use function React\Promise\resolve;
 
@@ -31,7 +32,8 @@ class DeploymentChecker implements DbBasedComponent
 
     /**
      * @param Db $connection
-     * @return \React\Promise\ExtendedPromiseInterface
+     *
+     * @return PromiseInterface
      */
     public function initDb(Db $connection)
     {
@@ -41,7 +43,7 @@ class DeploymentChecker implements DbBasedComponent
     }
 
     /**
-     * @return \React\Promise\ExtendedPromiseInterface
+     * @return PromiseInterface
      */
     public function stopDb()
     {

--- a/library/Director/Daemon/DeploymentChecker.php
+++ b/library/Director/Daemon/DeploymentChecker.php
@@ -39,7 +39,7 @@ class DeploymentChecker implements DbBasedComponent
     {
         $this->connection = $connection;
 
-        return resolve();
+        return resolve(null);
     }
 
     /**
@@ -49,6 +49,6 @@ class DeploymentChecker implements DbBasedComponent
     {
         $this->connection = null;
 
-        return resolve();
+        return resolve(null);
     }
 }

--- a/library/Director/Daemon/JobRunner.php
+++ b/library/Director/Daemon/JobRunner.php
@@ -2,7 +2,6 @@
 
 namespace Icinga\Module\Director\Daemon;
 
-use gipfl\IcingaCliDaemon\FinishedProcessState;
 use gipfl\IcingaCliDaemon\IcingaCliRpc;
 use Icinga\Application\Logger;
 use Icinga\Module\Director\Db;
@@ -206,8 +205,6 @@ class JobRunner implements DbBasedComponent
             Logger::debug("Job ($jobName) finished");
         })->catch(function (\Exception $e) use ($id, $jobName) {
             Logger::error("Job ($jobName) failed: " . $e->getMessage());
-        })->catch(function (FinishedProcessState $state) use ($jobName) {
-            Logger::error("Job ($jobName) failed: " . $state->getReason());
         })->finally(function () use ($id) {
             unset($this->runningIds[$id]);
             $this->loop->futureTick(function () {

--- a/library/Director/Daemon/JobRunner.php
+++ b/library/Director/Daemon/JobRunner.php
@@ -77,7 +77,7 @@ class JobRunner implements DbBasedComponent
         }
         $this->timer = $this->loop->addPeriodicTimer($this->checkInterval, $check);
 
-        return resolve();
+        return resolve(null);
     }
 
     /**

--- a/library/Director/Daemon/JobRunner.php
+++ b/library/Director/Daemon/JobRunner.php
@@ -205,11 +205,11 @@ class JobRunner implements DbBasedComponent
         unset($this->scheduledIds[$id]);
         $this->runningIds[$id] = $cli->run($this->loop)->then(function () use ($id, $jobName) {
             Logger::debug("Job ($jobName) finished");
-        })->otherwise(function (\Exception $e) use ($id, $jobName) {
+        })->catch(function (\Exception $e) use ($id, $jobName) {
             Logger::error("Job ($jobName) failed: " . $e->getMessage());
-        })->otherwise(function (FinishedProcessState $state) use ($jobName) {
+        })->catch(function (FinishedProcessState $state) use ($jobName) {
             Logger::error("Job ($jobName) failed: " . $state->getReason());
-        })->always(function () use ($id) {
+        })->finally(function () use ($id) {
             unset($this->runningIds[$id]);
             $this->loop->futureTick(function () {
                 $this->runNextPendingJob();

--- a/library/Director/Daemon/JobRunner.php
+++ b/library/Director/Daemon/JobRunner.php
@@ -9,7 +9,6 @@ use Icinga\Module\Director\Db;
 use Icinga\Module\Director\Objects\DirectorJob;
 use React\ChildProcess\Process;
 use React\EventLoop\LoopInterface;
-use React\Promise\Promise;
 use React\Promise\PromiseInterface;
 
 use function React\Promise\resolve;
@@ -25,7 +24,7 @@ class JobRunner implements DbBasedComponent
     /** @var int[] */
     protected $scheduledIds = [];
 
-    /** @var Promise[] */
+    /** @var PromiseInterface[] */
     protected $runningIds = [];
 
     protected $checkInterval = 10;

--- a/library/Director/Daemon/JobRunner.php
+++ b/library/Director/Daemon/JobRunner.php
@@ -10,6 +10,7 @@ use Icinga\Module\Director\Objects\DirectorJob;
 use React\ChildProcess\Process;
 use React\EventLoop\LoopInterface;
 use React\Promise\Promise;
+use React\Promise\PromiseInterface;
 
 use function React\Promise\resolve;
 
@@ -53,7 +54,8 @@ class JobRunner implements DbBasedComponent
 
     /**
      * @param Db $db
-     * @return \React\Promise\ExtendedPromiseInterface
+     *
+     * @return PromiseInterface
      */
     public function initDb(Db $db)
     {
@@ -79,7 +81,7 @@ class JobRunner implements DbBasedComponent
     }
 
     /**
-     * @return \React\Promise\ExtendedPromiseInterface
+     * @return PromiseInterface
      */
     public function stopDb()
     {

--- a/library/Director/Daemon/LogProxy.php
+++ b/library/Director/Daemon/LogProxy.php
@@ -4,6 +4,7 @@ namespace Icinga\Module\Director\Daemon;
 
 use Exception;
 use Icinga\Module\Director\Db;
+use React\Promise\PromiseInterface;
 
 use function React\Promise\resolve;
 
@@ -33,7 +34,8 @@ class LogProxy implements DbBasedComponent
 
     /**
      * @param Db $connection
-     * @return \React\Promise\ExtendedPromiseInterface
+     *
+     * @return PromiseInterface
      */
     public function initDb(Db $connection)
     {
@@ -44,7 +46,7 @@ class LogProxy implements DbBasedComponent
     }
 
     /**
-     * @return \React\Promise\ExtendedPromiseInterface
+     * @return PromiseInterface
      */
     public function stopDb()
     {

--- a/library/Director/Daemon/LogProxy.php
+++ b/library/Director/Daemon/LogProxy.php
@@ -42,7 +42,7 @@ class LogProxy implements DbBasedComponent
         $this->connection = $connection;
         $this->db = $connection->getDbAdapter();
 
-        return resolve();
+        return resolve(null);
     }
 
     /**
@@ -53,7 +53,7 @@ class LogProxy implements DbBasedComponent
         $this->connection = null;
         $this->db = null;
 
-        return resolve();
+        return resolve(null);
     }
 
     public function log($severity, $message)

--- a/library/Director/Daemon/ProcessList.php
+++ b/library/Director/Daemon/ProcessList.php
@@ -63,7 +63,7 @@ class ProcessList
     public function killOrTerminate($timeout = 5)
     {
         if ($this->processes->count() === 0) {
-            return resolve();
+            return resolve(null);
         }
         $deferred = new Deferred();
         $killTimer = $this->loop->addTimer($timeout, function () use ($deferred) {
@@ -76,7 +76,7 @@ class ProcessList
 
             // Let's a little bit of delay after KILLing
             $this->loop->addTimer(0.1, function () use ($deferred) {
-                $deferred->resolve();
+                $deferred->resolve(null);
             });
         });
 
@@ -98,7 +98,7 @@ class ProcessList
             if ($this->processes->count() === 0) {
                 $this->loop->cancelTimer($timer);
                 $this->loop->cancelTimer($killTimer);
-                $deferred->resolve();
+                $deferred->resolve(null);
             }
         });
         /** @var Process $process */

--- a/library/Director/Daemon/ProcessList.php
+++ b/library/Director/Daemon/ProcessList.php
@@ -8,6 +8,7 @@ use ipl\Stdlib\EventEmitter;
 use React\ChildProcess\Process;
 use React\EventLoop\LoopInterface;
 use React\Promise\Deferred;
+use React\Promise\PromiseInterface;
 
 use function React\Promise\resolve;
 
@@ -56,7 +57,8 @@ class ProcessList
 
     /**
      * @param int $timeout
-     * @return \React\Promise\ExtendedPromiseInterface
+     *
+     * @return PromiseInterface
      */
     public function killOrTerminate($timeout = 5)
     {


### PR DESCRIPTION
### Summary

- Upgrade `react/promise` to **v3**:
  - replace removed `ExtendedPromiseInterface` with `PromiseInterface`
  - pass required arguments to `resolve()` and `reject()`
  - rename `otherwise()`/`always()` to `catch()`/`finally()`
  - remove dead `FinishedProcessState` catch handler that can never trigger in v3 (because it doesn't implement the `Throwable` interface); `gipfl\IcingaCliDaemon\IcingaCli` already rejects with an Exception wrapping the process state reason
- Upgrade `react/event-loop` to **v1.6**:
  - replace deprecated `Factory::create()` with `Loop::get()`

### References

https://github.com/reactphp/promise/releases/tag/v3.0.0
https://github.com/reactphp/event-loop/releases/tag/v1.2.0

requires: 

- [x] Icinga/icinga-php-thirdparty#93