### PR TITLE
Revert the changes made for shardj/zf1-future compatibility in (#3035)

### DIFF
--- a/library/Director/Web/Form/Element/Boolean.php
+++ b/library/Director/Web/Form/Element/Boolean.php
@@ -43,7 +43,7 @@ class Boolean extends ZfSelect
      * @param string $key
      * @codingStandardsIgnoreStart
      */
-    protected function _filterValue(&$value, $key)
+    protected function _filterValue(&$value, &$key)
     {
         // @codingStandardsIgnoreEnd
         if ($value === true) {

--- a/library/Director/Web/Form/Element/DataFilter.php
+++ b/library/Director/Web/Form/Element/DataFilter.php
@@ -56,7 +56,7 @@ class DataFilter extends FormElement
      * @inheritdoc
      * @codingStandardsIgnoreStart
      */
-    protected function _filterValue(&$value, $key)
+    protected function _filterValue(&$value, &$key)
     {
         // @codingStandardsIgnoreEnd
         try {

--- a/library/Director/Web/Form/Element/ExtensibleSet.php
+++ b/library/Director/Web/Form/Element/ExtensibleSet.php
@@ -54,7 +54,7 @@ class ExtensibleSet extends FormElement
     /**
      * @codingStandardsIgnoreStart
      */
-    protected function _filterValue(&$value, $key)
+    protected function _filterValue(&$value, &$key)
     {
         // @codingStandardsIgnoreEnd
         if (is_array($value)) {


### PR DESCRIPTION
The patch that was dropped in icinga-php-thidparty version 0.15.0, will be applied in the Icinga/zf1 fork. And with the icinga-php-thirdparty version 0.15.1, this changes are obsolete and also will not break compatibility with earlier versions of icinga-php-thirdparty.

fixes #3056 