### PR TITLE
Feature/automation commands with names

### DIFF
--- a/application/clicommands/ImportsourceCommand.php
+++ b/application/clicommands/ImportsourceCommand.php
@@ -3,10 +3,13 @@
 namespace Icinga\Module\Director\Clicommands;
 
 use Icinga\Application\Benchmark;
+use Icinga\Exception\MissingParameterException;
+use Icinga\Exception\NotFoundError;
 use Icinga\Module\Director\Cli\Command;
 use Icinga\Module\Director\Core\Json;
 use Icinga\Module\Director\Hook\ImportSourceHook;
 use Icinga\Module\Director\Objects\ImportSource;
+use RuntimeException;
 
 /**
  * Deal with Director Import Sources
@@ -57,7 +60,8 @@ class ImportsourceCommand extends Command
      *
      * OPTIONS
      *
-     *   --id <id>     An Import Source ID. Use the list command to figure out
+     *   --id <id>     An Import Source ID. Use the list command to figure out. Should not be used together --name
+     *   --name <source_name> An Import Source Name. Should not be used together --id
      *   --benchmark   Show timing and memory usage details
      */
     public function checkAction()
@@ -76,7 +80,8 @@ class ImportsourceCommand extends Command
      *
      * OPTIONS
      *
-     *   --id <id>     An Import Source ID. Use the list command to figure out
+     *   --id <id>     An Import Source ID. Use the list command to figure out. Should not be used together --name
+     *   --name <source_name> An Import Source Name. Should not be used together --id
      */
     public function deleteAction()
     {
@@ -98,7 +103,8 @@ class ImportsourceCommand extends Command
      *
      * OPTIONS
      *
-     *   --id <id>     An Import Source ID. Use the list command to figure out
+     *   --id <id>     An Import Source ID. Use the list command to figure out. Should not be used together --name
+     *   --name <source_name> An Import Source Name. Should not be used together --id
      *   --benchmark   Show timing and memory usage details
      */
     public function fetchAction()
@@ -126,7 +132,8 @@ class ImportsourceCommand extends Command
      *
      * OPTIONS
      *
-     *   --id <id>     An Import Source ID. Use the list command to figure out
+     *   --id <id>     An Import Source ID. Use the list command to figure out. Should not be used together --name
+     *   --name <source_name> An Import Source Name. Should not be used together --id
      *   --benchmark   Show timing and memory usage details
      */
     public function runAction()
@@ -142,14 +149,33 @@ class ImportsourceCommand extends Command
     }
 
     /**
+     * Get the import source based on its id or name
+     *
      * @return ImportSource
+     *
+     * @throws MissingParameterException|RuntimeException|NotFoundError
      */
-    protected function getImportSource()
+    protected function getImportSource(): ImportSource
     {
-        return ImportSource::loadWithAutoIncId(
-            (int) $this->params->getRequired('id'),
-            $this->db()
-        );
+        $id = null;
+        if ($this->params->has('id')) {
+            $id = (int) $this->params->get('id');
+        }
+
+        $name = null;
+        if ($id === null) {
+            $name = $this->params->get('name');
+        }
+
+        if ($id === null && $name === null) {
+            throw new MissingParameterException($this->translate('Either --id or --name is required'));
+        } elseif ($id !== null && $name !== null) {
+            throw new RuntimeException('Only one of --id or --name may be used, not both');
+        } elseif ($id !== null) {
+            return ImportSource::loadWithAutoIncId($id, $this->db());
+        }
+
+        return ImportSource::load($name, $this->db());
     }
 
     /**

--- a/application/clicommands/SyncruleCommand.php
+++ b/application/clicommands/SyncruleCommand.php
@@ -2,6 +2,8 @@
 
 namespace Icinga\Module\Director\Clicommands;
 
+use Icinga\Exception\MissingParameterException;
+use Icinga\Exception\NotFoundError;
 use Icinga\Module\Director\Cli\Command;
 use Icinga\Module\Director\Objects\DirectorActivityLog;
 use Icinga\Module\Director\Objects\IcingaObject;
@@ -56,7 +58,8 @@ class SyncruleCommand extends Command
      *
      * OPTIONS
      *
-     *   --id <id>     A Sync Rule ID. Use the list command to figure out
+     *   --id <id>     A Sync Rule ID. Use the list command to figure out. Should not be used together --name
+     *   --name <rule_name> A Sync Rule name. Should not be used together --id
      *   --benchmark   Show timing and memory usage details
      */
     public function checkAction()
@@ -86,7 +89,8 @@ class SyncruleCommand extends Command
      *
      * OPTIONS
      *
-     *   --id <id>     A Sync Rule ID. Use the list command to figure out
+     *   --id <id>     A Sync Rule ID. Use the list command to figure out. Should not be used together --name
+     *   --name <rule_name> A Sync Rule name. Should not be used together --id
      */
     public function deleteAction()
     {
@@ -136,7 +140,8 @@ class SyncruleCommand extends Command
      *
      * OPTIONS
      *
-     *   --id <id>     A Sync Rule ID. Use the list command to figure out
+     *   --id <id>     A Sync Rule ID. Use the list command to figure out. Should not be used together --name
+     *   --name <rule_name> A Sync Rule name. Should not be used together --id
      *   --benchmark   Show timing and memory usage details
      */
     public function runAction()
@@ -152,14 +157,33 @@ class SyncruleCommand extends Command
     }
 
     /**
+     *  Get the sync rule based on its id or name
+     *
      * @return SyncRule
+     *
+     * @throws MissingParameterException|RuntimeException|NotFoundError
      */
-    protected function getSyncRule()
+    protected function getSyncRule(): SyncRule
     {
-        return SyncRule::loadWithAutoIncId(
-            (int) $this->params->getRequired('id'),
-            $this->db()
-        );
+        $id = null;
+        if ($this->params->has('id')) {
+            $id = (int) $this->params->get('id');
+        }
+
+        $name = null;
+        if ($id === null) {
+            $name = $this->params->get('name');
+        }
+
+        if ($id === null && $name === null) {
+            throw new MissingParameterException($this->translate('Either --id or --name is required'));
+        } elseif ($id !== null && $name !== null) {
+            throw new RuntimeException('Only one of --id or --name may be used, not both');
+        } elseif ($id !== null) {
+            return SyncRule::loadWithAutoIncId($id, $this->db());
+        }
+
+        return SyncRule::loadWithAutoIncId($name, $this->db());
     }
 
     /**


### PR DESCRIPTION
Before this change, the `importsource` and `syncrule` commands can check, run or delete import sources or sync rules only based on ids.

To find out the ids, you would have to either check the database or run the following commands:
For import source:
```shell
icingacli director importsource list
```
For sync rule:
```shell
icingacli director syncrule list
```

With this change, once the name of the import source or sync rule is known it can be passed to the `--name` option, to perform the required task.