### PR TITLE
Expose `display_name` field in the service form

### DIFF
--- a/application/forms/IcingaServiceForm.php
+++ b/application/forms/IcingaServiceForm.php
@@ -424,6 +424,7 @@ class IcingaServiceForm extends DirectorObjectForm
         $forceCommandElements = $this->hasPermission(Permission::ADMIN);
 
         $this->addNameElement()
+             ->addDisplayNameElement()
              ->addHostObjectElement()
              ->addImportsElement()
              ->addChoices('service')
@@ -570,6 +571,7 @@ class IcingaServiceForm extends DirectorObjectForm
         }
 
         $this->addNameElement()
+             ->addDisplayNameElement()
              ->addChoices('service')
              ->addDisabledElement()
              ->addGroupsElement()
@@ -612,6 +614,7 @@ class IcingaServiceForm extends DirectorObjectForm
         }
 
         $this->addNameElement()
+             ->addDisplayNameElement()
              ->addDisabledElement()
              ->addGroupsElement()
              ->groupMainProperties();
@@ -648,6 +651,28 @@ class IcingaServiceForm extends DirectorObjectForm
         if ($this->object()->isApplyRule()) {
             $this->eventuallyAddNameRestriction('director/service/apply/filter-by-name');
         }
+
+        return $this;
+    }
+
+    /**
+     * @return $this
+     * @throws \Zend_Form_Exception
+     */
+    protected function addDisplayNameElement()
+    {
+        if ($this->isTemplate()) {
+            return $this;
+        }
+
+        $this->addElement('text', 'display_name', array(
+            'label'       => $this->translate('Display name'),
+            'spellcheck'  => 'false',
+            'description' => $this->translate(
+                'Alternative name for this service. Might be a more user friendly'
+                . ' string helping your users to identify this service'
+            )
+        ));
 
         return $this;
     }

--- a/application/forms/IcingaServiceForm.php
+++ b/application/forms/IcingaServiceForm.php
@@ -423,6 +423,7 @@ class IcingaServiceForm extends DirectorObjectForm
         $forceCommandElements = $this->hasPermission(Permission::ADMIN);
 
         $this->addNameElement()
+             ->addDisplayNameElement()
              ->addHostObjectElement()
              ->addImportsElement()
              ->addChoices('service')
@@ -569,6 +570,7 @@ class IcingaServiceForm extends DirectorObjectForm
         }
 
         $this->addNameElement()
+             ->addDisplayNameElement()
              ->addChoices('service')
              ->addDisabledElement()
              ->addGroupsElement()
@@ -611,6 +613,7 @@ class IcingaServiceForm extends DirectorObjectForm
         }
 
         $this->addNameElement()
+             ->addDisplayNameElement()
              ->addDisabledElement()
              ->addGroupsElement()
              ->groupMainProperties();
@@ -647,6 +650,28 @@ class IcingaServiceForm extends DirectorObjectForm
         if ($this->object()->isApplyRule()) {
             $this->eventuallyAddNameRestriction('director/service/apply/filter-by-name');
         }
+
+        return $this;
+    }
+
+    /**
+     * @return $this
+     * @throws \Zend_Form_Exception
+     */
+    protected function addDisplayNameElement()
+    {
+        if ($this->isTemplate()) {
+            return $this;
+        }
+
+        $this->addElement('text', 'display_name', array(
+            'label'       => $this->translate('Display name'),
+            'spellcheck'  => 'false',
+            'description' => $this->translate(
+                'Alternative name for this service. Might be a more user friendly'
+                . ' string helping your users to identify this service'
+            )
+        ));
 
         return $this;
     }


### PR DESCRIPTION
The `display_name` property already exists on `IcingaService` and is rendered into the generated config, but the web form never exposed it, so it could only be set through manual SQL or the REST API. This adds a `Display name` text field to the service form, mirroring the existing host form behaviour.

A dedicated `addDisplayNameElement()` is added and wired into all three setup paths (service objects and apply rules, host-related services and service-set services), skipping templates just like the host form does.

Fixes #608
Fixes #2659
Fixes #2957
Refs #932
Refs #2509