### PR TITLE
Add PromiseUtil shim for react/promise v2/v3 compatibility

### DIFF
--- a/library/Director/Daemon/JobRunner.php
+++ b/library/Director/Daemon/JobRunner.php
@@ -9,6 +9,7 @@ use Icinga\Module\Director\Objects\DirectorJob;
 use React\ChildProcess\Process;
 use React\EventLoop\LoopInterface;
 use React\Promise\PromiseInterface;
+use Icinga\Module\Director\Daemon\PromiseUtil;
 
 use function React\Promise\resolve;
 
@@ -201,11 +202,13 @@ class JobRunner implements DbBasedComponent
             $cli->rpc()->setHandler($logger, 'logger');
         }
         unset($this->scheduledIds[$id]);
-        $this->runningIds[$id] = $cli->run($this->loop)->then(function () use ($id, $jobName) {
+        $promise = $cli->run($this->loop)->then(function () use ($id, $jobName) {
             Logger::debug("Job ($jobName) finished");
-        })->catch(function (\Exception $e) use ($id, $jobName) {
+        });
+        $promise = PromiseUtil::catch($promise, function (\Exception $e) use ($id, $jobName) {
             Logger::error("Job ($jobName) failed: " . $e->getMessage());
-        })->finally(function () use ($id) {
+        });
+        $this->runningIds[$id] = PromiseUtil::finally($promise, function () use ($id) {
             unset($this->runningIds[$id]);
             $this->loop->futureTick(function () {
                 $this->runNextPendingJob();

--- a/library/Director/Daemon/PromiseUtil.php
+++ b/library/Director/Daemon/PromiseUtil.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Icinga\Module\Director\Daemon;
+
+use React\Promise\PromiseInterface;
+
+/**
+ * Compatibility shim for react/promise v2 and v3.
+ *
+ * v3 renamed ->otherwise() to ->catch() and ->always() to ->finally().
+ * The runtime version is determined by the icinga-php-thirdparty bundle, so we
+ * probe with method_exists() rather than checking the installed package version.
+ */
+class PromiseUtil
+{
+    /**
+     * Calls ->catch() (react/promise v3) or ->otherwise() (react/promise v2)
+     *
+     * @param PromiseInterface $promise
+     * @param callable         $onRejected
+     *
+     * @return PromiseInterface
+     */
+    public static function catch(PromiseInterface $promise, callable $onRejected): PromiseInterface
+    {
+        if (method_exists($promise, 'catch')) {
+            return $promise->catch($onRejected);
+        }
+
+        return $promise->otherwise($onRejected);
+    }
+
+    /**
+     * Calls ->finally() (react/promise v3) or ->always() (react/promise v2)
+     *
+     * @param PromiseInterface $promise
+     * @param callable         $onFulfilledOrRejected
+     *
+     * @return PromiseInterface
+     */
+    public static function finally(PromiseInterface $promise, callable $onFulfilledOrRejected): PromiseInterface
+    {
+        if (method_exists($promise, 'finally')) {
+            return $promise->finally($onFulfilledOrRejected);
+        }
+
+        return $promise->always($onFulfilledOrRejected);
+    }
+}


### PR DESCRIPTION
Introduces PromiseUtil::catch() and PromiseUtil::finally() which probe the promise for the v3 method names and fall back to the v2 aliases (->otherwise() / ->always()) at runtime. This allows the codebase to run against whichever react/promise version is bundled by icinga-php-thirdparty without a compile-time constraint.

Updates JobRunner to use the shim instead of calling ->catch() and ->finally() directly.