### PR TITLE
Require `icinga-php-thirdparty` 0.15.3

### DIFF
--- a/doc/02-Installation.md.d/From-Source.md
+++ b/doc/02-Installation.md.d/From-Source.md
@@ -19,6 +19,9 @@ Make sure you use `director` as the module name. The following requirements must
           nodes
 * [Icinga Web](https://github.com/Icinga/icingaweb2) (≥2.8.0). All versions since 2.2 should also work fine, but
   might show smaller UI bugs and are not actively tested
+* The following Icinga PHP libraries must be installed:
+    * [icinga-php-library](https://github.com/Icinga/icinga-php-library) (≥0.14.2)
+    * [icinga-php-thirdparty](https://github.com/Icinga/icinga-php-thirdparty) (≥0.15.3)
 * The following Icinga modules must be installed and enabled:
     * [incubator](https://github.com/Icinga/icingaweb2-module-incubator) (≥0.22.0)
     * If you are using Icinga Web <2.9.0, the following modules are also required

--- a/module.info
+++ b/module.info
@@ -1,7 +1,7 @@
 Name: Icinga Director
 Version: 1.11.8
 Requires:
-  Libraries: icinga-php-library (>=0.14.2), icinga-php-thirdparty (>=0.12.1)
+  Libraries: icinga-php-library (>=0.14.2), icinga-php-thirdparty (>=0.15.3)
   Modules: incubator (>=0.22.0)
 Description: Director - Config tool for Icinga 2
  Icinga Director is a configuration tool that has been designed to make


### PR DESCRIPTION
Commit 5fc103ffc36b96ce1737973dd17059a629f413f8 introduced `react/async` to replace the abandoned `clue/block-react` library. The replacement is only available in the Icinga PHP Thirdparty bundle starting with version 0.15.