### PR TITLE
Raise minimum PHP requirement to PHP 8.2

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3']
+        php: ['8.2', '8.3', '8.4', '8.5']
         os: ['ubuntu-latest']
 
     steps:
@@ -48,7 +48,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['8.2', '8.3']
+        php: ['8.2', '8.3', '8.4', '8.5']
         os: ['ubuntu-latest']
 
     services:

--- a/doc/02-Installation.md.d/From-Source.md
+++ b/doc/02-Installation.md.d/From-Source.md
@@ -8,7 +8,7 @@ Make sure you use `director` as the module name. The following requirements must
 
 ## Requirements
 
-* PHP (≥7.3)
+* PHP (≥8.2)
     * Director v1.10 is the last version with support for PHP v5.6
 * [Icinga 2](https://github.com/Icinga/icinga2) (≥2.8.0)
     * It is recommended to use the latest feature release of Icinga 2


### PR DESCRIPTION
- Raise minimum PHP requirement to version 8.2
- Update CI to support PHP 8.4 and 8.5