### PR TITLE
IcingaTemplateChoiceForm: Fix associated service template lookup

### DIFF
--- a/application/forms/IcingaTemplateChoiceForm.php
+++ b/application/forms/IcingaTemplateChoiceForm.php
@@ -2,7 +2,6 @@
 
 namespace Icinga\Module\Director\Forms;
 
-use Icinga\Module\Director\Data\Db\DbObject;
 use Icinga\Module\Director\Db;
 use Icinga\Module\Director\Objects\IcingaTemplateChoice;
 use Icinga\Module\Director\Web\Form\DirectorObjectForm;
@@ -92,26 +91,20 @@ class IcingaTemplateChoiceForm extends DirectorObjectForm
             'value' => 1,
         ));
 
-        $this->addElement('select', 'required_template', [
+        $this->addElement('select', 'required_template_id', [
             'label'        => $this->translate('Associated Template'),
             'description'  => $this->translate(
                 'Choose Choice Associated Template'
             ),
             'required'     => true,
-            'multiOptions' => $this->fetchUnboundTemplates(),
+            'multiOptions' => $this->fetchUnboundTemplates(true),
         ]);
 
         $this->setButtons();
     }
 
-    protected function setDefaultsFromObject(DbObject $object)
-    {
-        parent::setDefaultsFromObject($object);
 
-        $this->getElement('required_template')->setValue($object->get('required_template'));
-    }
-
-    protected function fetchUnboundTemplates()
+    protected function fetchUnboundTemplates($useIdAsKey = false)
     {
         /** @var IcingaTemplateChoice $object */
         $object = $this->object();
@@ -120,7 +113,7 @@ class IcingaTemplateChoiceForm extends DirectorObjectForm
         $query = $db->select()->from(
             ['o' => $table],
             [
-                'k' => 'o.object_name',
+                'k' => $useIdAsKey ? 'o.id' : 'o.object_name',
                 'v' => 'o.object_name',
             ]
         )->where("o.object_type = 'template'");

--- a/test/php/library/Director/Form/IcingaTemplateChoiceFormTest.php
+++ b/test/php/library/Director/Form/IcingaTemplateChoiceFormTest.php
@@ -33,7 +33,7 @@ class IcingaTemplateChoiceFormTest extends BaseTestCase
 
         $associatedTemplates = $form
             ->getElement('required_template_id')
-            ->getAttrib('multiOptions');
+            ->getMultiOptions();
 
         $members = $form
             ->getElement('members')

--- a/test/php/library/Director/Form/IcingaTemplateChoiceFormTest.php
+++ b/test/php/library/Director/Form/IcingaTemplateChoiceFormTest.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Tests\Icinga\Module\Director\Form;
+
+use Icinga\Module\Director\Forms\IcingaTemplateChoiceForm;
+use Icinga\Module\Director\Objects\IcingaService;
+use Icinga\Module\Director\Test\BaseTestCase;
+
+class IcingaTemplateChoiceFormTest extends BaseTestCase
+{
+    protected const TEMPLATE_NAME = '___TEST___service_template_choice';
+
+    protected $templateId;
+
+    public function testServiceAssociatedTemplateUsesIdAsOptionKey()
+    {
+        if ($this->skipForMissingDb()) {
+            return;
+        }
+
+        $db = $this->getDb();
+
+        $template = IcingaService::create([
+            'object_name' => self::TEMPLATE_NAME,
+            'object_type' => 'template',
+        ], $db);
+        $template->store();
+
+        $this->templateId = $template->get('id');
+
+        $form = IcingaTemplateChoiceForm::create('service', $db);
+        $form->setup();
+
+        $associatedTemplates = $form
+            ->getElement('required_template_id')
+            ->getMultiOptions();
+
+        $members = $form
+            ->getElement('members')
+            ->getMultiOptions();
+
+        $this->assertArrayHasKey(
+            $this->templateId,
+            $associatedTemplates
+        );
+        $this->assertSame(
+            self::TEMPLATE_NAME,
+            $associatedTemplates[$this->templateId]
+        );
+
+        $this->assertArrayHasKey(
+            self::TEMPLATE_NAME,
+            $members
+        );
+        $this->assertSame(
+            self::TEMPLATE_NAME,
+            $members[self::TEMPLATE_NAME]
+        );
+    }
+
+    public function tearDown(): void
+    {
+        if ($this->hasDb() && $this->templateId !== null) {
+            IcingaService::loadWithAutoIncId(
+                $this->templateId,
+                $this->getDb()
+            )->delete();
+        }
+
+        parent::tearDown();
+    }
+}

--- a/test/php/library/Director/Form/IcingaTemplateChoiceFormTest.php
+++ b/test/php/library/Director/Form/IcingaTemplateChoiceFormTest.php
@@ -33,11 +33,11 @@ class IcingaTemplateChoiceFormTest extends BaseTestCase
 
         $associatedTemplates = $form
             ->getElement('required_template_id')
-            ->getMultiOptions();
+            ->getAttrib('multiOptions');
 
         $members = $form
             ->getElement('members')
-            ->getMultiOptions();
+            ->getAttrib('multiOptions');
 
         $this->assertArrayHasKey(
             $this->templateId,


### PR DESCRIPTION
Service template choices currently submit the associated template by object name. This causes the generic relation resolver to call IcingaService::load() with a scalar value, while IcingaService uses a multi-column key, resulting in: icinga_service has a multicolumn key, array required.

Use the existing required_template_id foreign key directly for the Associated Template form element instead. Available Choices continue to use object names as before.

A regression test verifies that service associated templates use their numeric ID as the option key while choice members still use the template name.

Fixes #2839