### PR TITLE
Skip nonexistent hostgroups in director/filter/hostgroups restrictions

### DIFF
--- a/library/Director/Restriction/HostgroupRestriction.php
+++ b/library/Director/Restriction/HostgroupRestriction.php
@@ -60,7 +60,7 @@ class HostgroupRestriction extends ObjectRestriction
 
         // Hint: branched hosts have no id
         if (! $host->hasBeenLoadedFromDb() || $host->hasModifiedGroups() || $host->get('id') === null) {
-            foreach ($this->listRestrictedHostgroups() as $group) {
+            foreach ($this->listRestrictedHostgroupsFromDb() as $group) {
                 if ($host->hasGroup($group) || $this->matchesHostGroupFilter($group, $host)) {
                     return true;
                 }
@@ -133,14 +133,14 @@ class HostgroupRestriction extends ObjectRestriction
         IcingaObjectFilterHelper::filterByResolvedHostgroups(
             $query,
             'host',
-            $this->listRestrictedHostgroups(),
+            $this->listRestrictedHostgroupsFromDb(),
             $tableAlias
         );
     }
 
     public function filterRestrictedHostgroups(array $groups)
     {
-        return array_intersect($groups, $this->listRestrictedHostgroups());
+        return array_intersect($groups, $this->listRestrictedHostgroupsFromDb());
     }
 
     /**
@@ -158,7 +158,7 @@ class HostgroupRestriction extends ObjectRestriction
         if (! $this->isRestricted()) {
             return;
         }
-        $groups = $this->listRestrictedHostgroups();
+        $groups = $this->listRestrictedHostgroupsFromDb();
 
         if (empty($groups)) {
             $query->where('(1 = 0)');
@@ -181,15 +181,6 @@ class HostgroupRestriction extends ObjectRestriction
             $groups = array();
             foreach ($restrictions as $restriction) {
                 foreach ($this->gracefullySplitOnComma($restriction) as $group) {
-                    if (! $this->db->fetchOne(
-                        $this->db->select()
-                            ->from('icinga_hostgroup', 'id')
-                            ->where('object_name = ?', $group)
-                    ))
-                    {
-                        continue;
-                    }
-
                     $groups[$group] = $group;
                 }
             }
@@ -198,5 +189,29 @@ class HostgroupRestriction extends ObjectRestriction
         } else {
             return null;
         }
+    }
+
+    /**
+     * Give a list of restricted Hostgroups that exist in the database.
+     *
+     * This filters out Hostgroups that are configured in the restriction but
+     * do not exist in Icinga DB.
+     *
+     * @return array
+     */
+
+    protected function listRestrictedHostgroupsFromDb()
+    {
+        $groups = $this->listRestrictedHostgroups();
+        if (empty($groups)) {
+            return [];
+        }
+
+        $query = $this->db->select()->from(
+            ['icinga_hostgroup'],
+            ['object_name']
+        )->where('object_name IN (?)', $groups);
+
+        return $this->db->fetchCol($query);
     }
 }

--- a/library/Director/Restriction/HostgroupRestriction.php
+++ b/library/Director/Restriction/HostgroupRestriction.php
@@ -181,6 +181,15 @@ class HostgroupRestriction extends ObjectRestriction
             $groups = array();
             foreach ($restrictions as $restriction) {
                 foreach ($this->gracefullySplitOnComma($restriction) as $group) {
+                    if (! $this->db->fetchOne(
+                        $this->db->select()
+                            ->from('icinga_hostgroup', 'id')
+                            ->where('object_name = ?', $group)
+                    ))
+                    {
+                        continue;
+                    }
+
                     $groups[$group] = $group;
                 }
             }

--- a/library/Director/Restriction/HostgroupRestriction.php
+++ b/library/Director/Restriction/HostgroupRestriction.php
@@ -195,11 +195,10 @@ class HostgroupRestriction extends ObjectRestriction
      * Give a list of restricted Hostgroups that exist in the database.
      *
      * This filters out Hostgroups that are configured in the restriction but
-     * do not exist in Icinga DB.
+     * do not exist in Director database.
      *
      * @return array
      */
-
     protected function listRestrictedHostgroupsFromDb()
     {
         $groups = $this->listRestrictedHostgroups();


### PR DESCRIPTION
This is my attempt at resolving #3098.

This PR adjusts `listRestrictedHostgroups()` to check each restricted hostgroup name against the `icinga_hostgroup` table, and skips names with no matching row, instead of passing every name through unchecked. This prevents a deleted hostgroup still referenced in a role restriction being evaluated by the filters.

Feedback is appreciated!