### PR TITLE
Fix pending resolve cache count

### DIFF
--- a/library/Director/Db/Housekeeping.php
+++ b/library/Director/Db/Housekeeping.php
@@ -238,7 +238,9 @@ class Housekeeping
     public function countResolveCache()
     {
         $helper = MembershipHousekeeping::instance('host', $this->connection);
-        return array_sum($helper->check());
+        list($newMappings, $outdatedMappings) = $helper->check();
+
+        return count($newMappings) + count($outdatedMappings);
     }
 
     public function wipeResolveCache()

--- a/library/Director/Db/Housekeeping.php
+++ b/library/Director/Db/Housekeeping.php
@@ -238,7 +238,7 @@ class Housekeeping
     public function countResolveCache()
     {
         $helper = MembershipHousekeeping::instance('host', $this->connection);
-        list($newMappings, $outdatedMappings) = $helper->check();
+        [$newMappings, $outdatedMappings] = $helper->check();
 
         return count($newMappings) + count($outdatedMappings);
     }


### PR DESCRIPTION
The housekeeping summary applies `array_sum()` directly to the two arrays returned by `MembershipHousekeeping::check()`, causing pending resolve-cache membership changes to be reported incorrectly.

Count new and outdated mappings separately so that the `resolveCache` task reports the actual number of pending membership changes.

## Testing

- `git diff --check`
- PHP syntax check not run locally because PHP is not installed

Fixes #3100