### PR TITLE
Add group add (+=) and remove (-=) functionality

### DIFF
--- a/application/forms/IcingaHostForm.php
+++ b/application/forms/IcingaHostForm.php
@@ -235,6 +235,25 @@ class IcingaHostForm extends DirectorObjectForm
             )
         ));
 
+        $this->addElement('extensibleSet', 'groupsadd', array(
+            'label'        => $this->translate('Groups (add)'),
+            'suggest'      => 'hostgroupnames',
+            'description'  => $this->translate(
+                'Hostgroups that should be added to the ones inherited from imported templates,'
+                . ' rendered as "groups += [ ... ]". Use this when you want to extend the group'
+                . ' assignment of your templates instead of replacing it.'
+            )
+        ));
+
+        $this->addElement('extensibleSet', 'groupsremove', array(
+            'label'        => $this->translate('Groups (remove)'),
+            'suggest'      => 'hostgroupnames',
+            'description'  => $this->translate(
+                'Hostgroups that should be removed from the ones inherited from imported'
+                . ' templates, rendered as "groups -= [ ... ]".'
+            )
+        ));
+
         $applied = $this->getAppliedGroups();
         if ($this->hasHostGroupRestriction()) {
             $applied = (new HostgroupRestriction($this->getDb(), $this->getAuth()))

--- a/application/forms/IcingaServiceForm.php
+++ b/application/forms/IcingaServiceForm.php
@@ -15,6 +15,7 @@ use Icinga\Module\Director\Objects\IcingaHost;
 use Icinga\Module\Director\Objects\IcingaService;
 use Icinga\Module\Director\Objects\IcingaServiceSet;
 use Icinga\Module\Director\Web\Table\ObjectsTableHost;
+use ipl\Html\BaseHtmlElement;
 use ipl\Html\Html;
 use gipfl\IcingaWeb2\Link;
 use ipl\Html\HtmlElement;
@@ -706,19 +707,16 @@ class IcingaServiceForm extends DirectorObjectForm
      * @return $this
      * @throws \Zend_Form_Exception
      */
-    /*
-     * Only the '=' operator is offered here, '+=' and '-=' memberships can
-     * still be maintained through Sync rules or the REST API. As setGroups()
-     * is scoped to '=', saving this form will not drop them.
-     */
     protected function addGroupsElement()
     {
         $groups = $this->enumServicegroups();
 
         if (! empty($groups)) {
+            $enum = $this->optionallyAddFromEnum($groups);
+
             $this->addElement('extensibleSet', 'groups', array(
                 'label'        => $this->translate('Groups'),
-                'multiOptions' => $this->optionallyAddFromEnum($groups),
+                'multiOptions' => $enum,
                 'positional'   => false,
                 'description'  => $this->translate(
                     'Service groups that should be directly assigned to this service.'
@@ -727,6 +725,28 @@ class IcingaServiceForm extends DirectorObjectForm
                     . ' either for custom dashboards or as an instrument to enforce'
                     . ' restrictions. Service groups can be directly assigned to'
                     . ' single services or to service templates.'
+                )
+            ));
+
+            $this->addElement('extensibleSet', 'groupsadd', array(
+                'label'        => $this->translate('Groups (add)'),
+                'multiOptions' => $enum,
+                'positional'   => false,
+                'description'  => $this->translate(
+                    'Service groups that should be added to the ones inherited from'
+                    . ' imported templates, rendered as "groups += [ ... ]". Use this'
+                    . ' when you want to extend the group assignment of your templates'
+                    . ' instead of replacing it.'
+                )
+            ));
+
+            $this->addElement('extensibleSet', 'groupsremove', array(
+                'label'        => $this->translate('Groups (remove)'),
+                'multiOptions' => $enum,
+                'positional'   => false,
+                'description'  => $this->translate(
+                    'Service groups that should be removed from the ones inherited from'
+                    . ' imported templates, rendered as "groups -= [ ... ]".'
                 )
             ));
         }
@@ -740,7 +760,41 @@ class IcingaServiceForm extends DirectorObjectForm
             ]);
         }
 
+        $inherited = $this->getInheritedGroups();
+        if (! empty($inherited)) {
+            /** @var BaseHtmlElement $links */
+            $links = $this->createServicegroupLinks($inherited);
+            if (count($this->object()->getGroups())) {
+                $links->addAttributes(['class' => 'strike-links']);
+                /** @var BaseHtmlElement $link */
+                foreach ($links->getContent() as $link) {
+                    if ($link instanceof BaseHtmlElement) {
+                        $link->addAttributes([
+                            'title' => $this->translate(
+                                'Group has been inherited, but will be overridden'
+                                . ' by locally assigned group(s)'
+                            )
+                        ]);
+                    }
+                }
+            }
+            $this->addElement('simpleNote', 'inherited_groups', [
+                'label'  => $this->translate('Inherited groups'),
+                'value'  => $links,
+                'ignore' => true,
+            ]);
+        }
+
         return $this;
+    }
+
+    protected function getInheritedGroups()
+    {
+        if ($this->hasObject()) {
+            return $this->object->listInheritedGroupNames();
+        }
+
+        return [];
     }
 
     /**

--- a/application/forms/IcingaServiceForm.php
+++ b/application/forms/IcingaServiceForm.php
@@ -706,6 +706,11 @@ class IcingaServiceForm extends DirectorObjectForm
      * @return $this
      * @throws \Zend_Form_Exception
      */
+    /*
+     * Only the '=' operator is offered here, '+=' and '-=' memberships can
+     * still be maintained through Sync rules or the REST API. As setGroups()
+     * is scoped to '=', saving this form will not drop them.
+     */
     protected function addGroupsElement()
     {
         $groups = $this->enumServicegroups();

--- a/application/forms/IcingaUserForm.php
+++ b/application/forms/IcingaUserForm.php
@@ -101,6 +101,11 @@ class IcingaUserForm extends DirectorObjectForm
      * @return $this
      * @throws \Zend_Form_Exception
      */
+    /*
+     * Only the '=' operator is offered here, '+=' and '-=' memberships can
+     * still be maintained through Sync rules or the REST API. As setGroups()
+     * is scoped to '=', saving this form will not drop them.
+     */
     protected function addGroupsElement()
     {
         $groups = $this->enumUsergroups();

--- a/application/forms/SyncPropertyForm.php
+++ b/application/forms/SyncPropertyForm.php
@@ -316,6 +316,8 @@ class SyncPropertyForm extends DirectorObjectForm
             }
             if ($dummy->supportsGroups()) {
                 $special['groups']  = $this->translate('Group membership');
+                $special['groupsadd']  = $this->translate('Group membership (Add)');
+                $special['groupsremove']  = $this->translate('Group membership (Remove)');
             }
             if ($dummy->supportsRanges()) {
                 $special['ranges']  = $this->translate('Time ranges');

--- a/library/Director/Db/Branch/BranchSettings.php
+++ b/library/Director/Db/Branch/BranchSettings.php
@@ -12,7 +12,15 @@ use function in_array;
 class BranchSettings
 {
     // TODO: Ranges is weird. key = scheduled_downtime_id, range_type, range_key
-    public const ENCODED_ARRAYS = ['imports', 'groups', 'ranges', 'users', 'usergroups'];
+    public const ENCODED_ARRAYS = [
+        'imports',
+        'groups',
+        'groupsadd',
+        'groupsremove',
+        'ranges',
+        'users',
+        'usergroups'
+    ];
 
     public const ENCODED_DICTIONARIES = ['vars', 'arguments'];
 

--- a/library/Director/Db/Cache/GroupMembershipCache.php
+++ b/library/Director/Db/Cache/GroupMembershipCache.php
@@ -16,6 +16,9 @@ class GroupMembershipCache
 
     protected $memberships;
 
+    /** @var array object id => (group name => operator) */
+    protected $operators;
+
     /** @var Db Director database connection */
     protected $connection;
 
@@ -37,6 +40,7 @@ class GroupMembershipCache
     {
         $db = $this->connection->getDbAdapter();
         $this->memberships = array();
+        $this->operators = array();
 
         $type  = $this->type;
         $table = $this->table;
@@ -47,6 +51,7 @@ class GroupMembershipCache
                 'object_id'   => 'o.id',
                 'group_id'    => 'g.id',
                 'group_name'  => 'g.object_name',
+                'operator'    => 'go.operator',
             )
         )->join(
             array('go' => $table . 'group_' . $type),
@@ -61,9 +66,11 @@ class GroupMembershipCache
         foreach ($db->fetchAll($query) as $row) {
             if (! array_key_exists($row->object_id, $this->memberships)) {
                 $this->memberships[$row->object_id] = array();
+                $this->operators[$row->object_id] = array();
             }
 
             $this->memberships[$row->object_id][$row->group_id] = $row->group_name;
+            $this->operators[$row->object_id][$row->group_name] = $row->operator;
         }
     }
 
@@ -80,6 +87,21 @@ class GroupMembershipCache
     {
         if (array_key_exists($object->id, $this->memberships)) {
             return array_keys($this->memberships[$object->id]);
+        }
+
+        return array();
+    }
+
+    /**
+     * Group membership operators for the given object, keyed by group name
+     *
+     * @param IcingaObject $object
+     * @return array
+     */
+    public function getOperatorsForObject(IcingaObject $object)
+    {
+        if (array_key_exists($object->id, $this->operators)) {
+            return $this->operators[$object->id];
         }
 
         return array();

--- a/library/Director/Db/Cache/PrefetchCache.php
+++ b/library/Director/Db/Cache/PrefetchCache.php
@@ -81,6 +81,11 @@ class PrefetchCache
         return $this->groupsCache($object)->getGroupsForObject($object);
     }
 
+    public function groupOperators(IcingaObject $object)
+    {
+        return $this->groupsCache($object)->getOperatorsForObject($object);
+    }
+
     /* Hint: not implemented, this happens in DbObject right now
     public function byObjectType($type)
     {

--- a/library/Director/Import/Sync.php
+++ b/library/Director/Import/Sync.php
@@ -17,6 +17,7 @@ use Icinga\Module\Director\Objects\IcingaHost;
 use Icinga\Module\Director\Objects\IcingaHostGroup;
 use Icinga\Module\Director\Objects\IcingaObject;
 use Icinga\Module\Director\Objects\IcingaObjectGroup;
+use Icinga\Module\Director\Objects\IcingaObjectGroups;
 use Icinga\Module\Director\Objects\ImportSource;
 use Icinga\Module\Director\Objects\IcingaService;
 use Icinga\Module\Director\Objects\SyncProperty;
@@ -576,7 +577,15 @@ class Sync
                     }
                 } elseif ($prop === 'groups') {
                     if ($val !== null) {
-                        $object->groups()->add($val);
+                        $object->groups()->add($val, 'fail', IcingaObjectGroups::OP_ASSIGN);
+                    }
+                } elseif ($prop === 'groupsadd') {
+                    if ($val !== null) {
+                        $object->groups()->add($val, 'fail', IcingaObjectGroups::OP_ADD);
+                    }
+                } elseif ($prop === 'groupsremove') {
+                    if ($val !== null) {
+                        $object->groups()->add($val, 'fail', IcingaObjectGroups::OP_REMOVE);
                     }
                 } elseif (substr($prop, 0, 5) === 'vars.') {
                     $varName = substr($prop, 5);

--- a/library/Director/Objects/GroupMembershipResolver.php
+++ b/library/Director/Objects/GroupMembershipResolver.php
@@ -538,10 +538,9 @@ abstract class GroupMembershipResolver
             }
 
             // can only be run reliably when updating for all groups
-            $groupNames = $object->get('groups');
-            if (empty($groupNames)) {
-                $groupNames = $object->listInheritedGroupNames();
-            }
+            // Honours the per-membership operator: '=' and '+=' are members,
+            // '-=' is not - not even when the group has been inherited
+            $groupNames = $object->listResolvedGroupNames();
             foreach ($groupNames as $name) {
                 $groupId = $this->getGroupId($name);
                 if (! array_key_exists($groupId, $mappings)) {

--- a/library/Director/Objects/IcingaObject.php
+++ b/library/Director/Objects/IcingaObject.php
@@ -1175,21 +1175,59 @@ abstract class IcingaObject extends DbObject implements IcingaConfigRenderer
     }
 
     /**
+     * Apply this object's own group operators on top of the given group list
+     *
+     * This mirrors how Icinga evaluates the rendered configuration, where the
+     * last line wins: "groups = [ ... ]" resets whatever has been accumulated
+     * so far, "+=" adds to it and "-=" strips from it.
+     *
+     * @param array $groups
+     * @return array
+     * @throws NotFoundError
+     */
+    public function applyGroupOperatorsTo(array $groups)
+    {
+        $assigned = $this->groups()->listGroupNamesForOperator(IcingaObjectGroups::OP_ASSIGN);
+        if (! empty($assigned)) {
+            $groups = $assigned;
+        }
+
+        $groups = array_merge(
+            $groups,
+            $this->groups()->listGroupNamesForOperator(IcingaObjectGroups::OP_ADD)
+        );
+
+        return array_values(array_diff(
+            array_unique($groups),
+            $this->groups()->listGroupNamesForOperator(IcingaObjectGroups::OP_REMOVE)
+        ));
+    }
+
+    /**
+     * The groups inherited from all imported templates
+     *
+     * Ancestors are returned in Icinga's own evaluation order (grandparents
+     * before parents, imports in declaration order), so folding them one after
+     * another gives exactly what Icinga computes for the imports. Accumulating
+     * matters: a template removing a group must be able to strip a group that
+     * an earlier template added.
+     *
      * @return array
      * @throws NotFoundError
      */
     public function listInheritedGroupNames()
     {
-        $parents = $this->imports()->getObjects();
-        /** @var IcingaObject $parent */
-        foreach (array_reverse($parents) as $parent) {
-            $inherited = $parent->listEffectiveGroupNames();
-            if (! empty($inherited)) {
-                return $inherited;
-            }
+        if (! $this->supportsImports()) {
+            return [];
         }
 
-        return [];
+        $groups = [];
+        /** @var IcingaObject $parent */
+        foreach ($this->templates()->getTemplatesFor($this, true) as $parent) {
+            $groups = $parent->applyGroupOperatorsTo($groups);
+        }
+
+        return $groups;
     }
 
     public function setGroups($groups)
@@ -1213,25 +1251,14 @@ abstract class IcingaObject extends DbObject implements IcingaConfigRenderer
     /**
      * The groups this object really ends up with, inheritance included
      *
-     * A local "groups = " overrides whatever has been inherited, "groups +="
-     * extends it and "groups -=" strips from it. This mirrors what Icinga
-     * itself computes when rendering the configuration.
+     * This is what Icinga will compute for the rendered object.
      *
      * @return array
      * @throws NotFoundError
      */
     public function listResolvedGroupNames()
     {
-        $assigned = $this->groups()->listGroupNamesForOperator(IcingaObjectGroups::OP_ASSIGN);
-        $added    = $this->groups()->listGroupNamesForOperator(IcingaObjectGroups::OP_ADD);
-        $removed  = $this->groups()->listGroupNamesForOperator(IcingaObjectGroups::OP_REMOVE);
-
-        $groups = empty($assigned) ? $this->listInheritedGroupNames() : $assigned;
-
-        return array_values(array_diff(
-            array_unique(array_merge($groups, $added)),
-            $removed
-        ));
+        return $this->applyGroupOperatorsTo($this->listInheritedGroupNames());
     }
 
     /**

--- a/library/Director/Objects/IcingaObject.php
+++ b/library/Director/Objects/IcingaObject.php
@@ -1132,12 +1132,46 @@ abstract class IcingaObject extends DbObject implements IcingaConfigRenderer
     }
 
     /**
+     * Groups assigned with the '=' operator
+     *
      * This is mostly for magic getters
      * @return array
      */
     public function getGroups()
     {
-        return $this->groups()->listGroupNames();
+        return $this->groups()->listGroupNamesForOperator(IcingaObjectGroups::OP_ASSIGN);
+    }
+
+    /**
+     * Groups added with the '+=' operator
+     *
+     * This is mostly for magic getters
+     * @return array
+     */
+    public function getGroupsadd()
+    {
+        return $this->groups()->listGroupNamesForOperator(IcingaObjectGroups::OP_ADD);
+    }
+
+    /**
+     * Groups removed with the '-=' operator
+     *
+     * This is mostly for magic getters
+     * @return array
+     */
+    public function getGroupsremove()
+    {
+        return $this->groups()->listGroupNamesForOperator(IcingaObjectGroups::OP_REMOVE);
+    }
+
+    /**
+     * Groups this object ends up with on its own: '=' and '+=' minus '-='
+     *
+     * @return array
+     */
+    public function listEffectiveGroupNames()
+    {
+        return $this->groups()->listEffectiveGroupNames();
     }
 
     /**
@@ -1149,7 +1183,7 @@ abstract class IcingaObject extends DbObject implements IcingaConfigRenderer
         $parents = $this->imports()->getObjects();
         /** @var IcingaObject $parent */
         foreach (array_reverse($parents) as $parent) {
-            $inherited = $parent->getGroups();
+            $inherited = $parent->listEffectiveGroupNames();
             if (! empty($inherited)) {
                 return $inherited;
             }
@@ -1160,22 +1194,44 @@ abstract class IcingaObject extends DbObject implements IcingaConfigRenderer
 
     public function setGroups($groups)
     {
-        $this->groups()->set($groups);
+        $this->groups()->set($groups, IcingaObjectGroups::OP_ASSIGN);
+        return $this;
+    }
+
+    public function setGroupsadd($groups)
+    {
+        $this->groups()->set($groups, IcingaObjectGroups::OP_ADD);
+        return $this;
+    }
+
+    public function setGroupsremove($groups)
+    {
+        $this->groups()->set($groups, IcingaObjectGroups::OP_REMOVE);
         return $this;
     }
 
     /**
+     * The groups this object really ends up with, inheritance included
+     *
+     * A local "groups = " overrides whatever has been inherited, "groups +="
+     * extends it and "groups -=" strips from it. This mirrors what Icinga
+     * itself computes when rendering the configuration.
+     *
      * @return array
      * @throws NotFoundError
      */
     public function listResolvedGroupNames()
     {
-        $groups = $this->groups()->listGroupNames();
-        if (empty($groups)) {
-            return $this->listInheritedGroupNames();
-        }
+        $assigned = $this->groups()->listGroupNamesForOperator(IcingaObjectGroups::OP_ASSIGN);
+        $added    = $this->groups()->listGroupNamesForOperator(IcingaObjectGroups::OP_ADD);
+        $removed  = $this->groups()->listGroupNamesForOperator(IcingaObjectGroups::OP_REMOVE);
 
-        return $groups;
+        $groups = empty($assigned) ? $this->listInheritedGroupNames() : $assigned;
+
+        return array_values(array_diff(
+            array_unique(array_merge($groups, $added)),
+            $removed
+        ));
     }
 
     /**
@@ -2808,7 +2864,11 @@ abstract class IcingaObject extends DbObject implements IcingaConfigRenderer
 
         if ($object->supportsGroups()) {
             $groups = $object->getGroups();
+            $groupsAdd = $object->getGroupsadd();
+            $groupsRemove = $object->getGroupsremove();
             $object->set('groups', []);
+            $object->set('groupsadd', []);
+            $object->set('groupsremove', []);
         }
 
         if ($object->supportsImports()) {
@@ -2817,7 +2877,13 @@ abstract class IcingaObject extends DbObject implements IcingaConfigRenderer
         }
 
         $plain = (array) $object->toPlainObject(false, false);
-        unset($plain['vars'], $plain['groups'], $plain['imports']);
+        unset(
+            $plain['vars'],
+            $plain['groups'],
+            $plain['groupsadd'],
+            $plain['groupsremove'],
+            $plain['imports']
+        );
         foreach ($plain as $p => $v) {
             if ($v === null) {
                 // We want default values, but no null values
@@ -2842,6 +2908,12 @@ abstract class IcingaObject extends DbObject implements IcingaConfigRenderer
         if ($object->supportsGroups()) {
             if (! empty($groups)) {
                 $this->set('groups', $groups);
+            }
+            if (! empty($groupsAdd)) {
+                $this->set('groupsadd', $groupsAdd);
+            }
+            if (! empty($groupsRemove)) {
+                $this->set('groupsremove', $groupsRemove);
             }
         }
 
@@ -2928,13 +3000,17 @@ abstract class IcingaObject extends DbObject implements IcingaConfigRenderer
         }
 
         if ($this->supportsGroups()) {
-            // TODO: resolve
-            $groups = $this->groups()->listGroupNames();
-            if ($resolved && empty($groups)) {
-                $groups = $this->listInheritedGroupNames();
+            if ($resolved) {
+                // Flattened: the groups this object really ends up with. This
+                // is what apply rules match against, so it must stay a plain
+                // list of names without any operator information
+                $props['groups'] = $this->listResolvedGroupNames();
+            } else {
+                // Round-trippable: one list per operator
+                $props['groups'] = $this->getGroups();
+                $props['groupsadd'] = $this->getGroupsadd();
+                $props['groupsremove'] = $this->getGroupsremove();
             }
-
-            $props['groups'] = $groups;
         }
 
         foreach ($this->loadAllMultiRelations() as $key => $rel) {
@@ -2983,8 +3059,10 @@ abstract class IcingaObject extends DbObject implements IcingaConfigRenderer
                     unset($props['vars']);
                 }
             }
-            if (empty($props['groups'])) {
-                unset($props['groups']);
+            foreach (['groups', 'groupsadd', 'groupsremove'] as $key) {
+                if (array_key_exists($key, $props) && empty($props[$key])) {
+                    unset($props[$key]);
+                }
             }
         }
 
@@ -3192,9 +3270,16 @@ abstract class IcingaObject extends DbObject implements IcingaConfigRenderer
             }
         }
         if ($this->supportsGroups()) {
-            $groups = $this->groups()->listOriginalGroupNames();
-            if (! empty($groups)) {
-                $props['groups'] = $groups;
+            $originalGroups = [
+                'groups'       => IcingaObjectGroups::OP_ASSIGN,
+                'groupsadd'    => IcingaObjectGroups::OP_ADD,
+                'groupsremove' => IcingaObjectGroups::OP_REMOVE,
+            ];
+            foreach ($originalGroups as $key => $operator) {
+                $groups = $this->groups()->listOriginalGroupNamesForOperator($operator);
+                if (! empty($groups)) {
+                    $props[$key] = $groups;
+                }
             }
         }
         if ($this->supportsImports()) {

--- a/library/Director/Objects/IcingaObjectGroups.php
+++ b/library/Director/Objects/IcingaObjectGroups.php
@@ -9,14 +9,33 @@ use Icinga\Module\Director\Db\Cache\PrefetchCache;
 use Icinga\Module\Director\IcingaConfig\IcingaConfigRenderer;
 use Icinga\Module\Director\IcingaConfig\IcingaConfigHelper as c;
 use Icinga\Module\Director\IcingaConfig\IcingaLegacyConfigHelper as c1;
+use InvalidArgumentException;
 use Iterator;
 use RuntimeException;
 
 class IcingaObjectGroups implements Iterator, Countable, IcingaConfigRenderer
 {
+    /** Assign group membership, rendered as "groups = [ ... ]" */
+    const OP_ASSIGN = '=';
+
+    /** Add to inherited group membership, rendered as "groups += [ ... ]" */
+    const OP_ADD = '+=';
+
+    /** Remove from inherited group membership, rendered as "groups -= [ ... ]" */
+    const OP_REMOVE = '-=';
+
+    /** All valid operators, in the order they have to be rendered */
+    const OPERATORS = array('=', '+=', '-=');
+
     protected $storedGroups = array();
 
     protected $groups = array();
+
+    /** @var array group name => operator */
+    protected $operators = array();
+
+    /** @var array group name => operator, as currently stored in the DB */
+    protected $storedOperators = array();
 
     protected $modified = false;
 
@@ -35,6 +54,108 @@ class IcingaObjectGroups implements Iterator, Countable, IcingaConfigRenderer
             $class = $this->getGroupClass();
             $class::prefetchAll($this->object->getConnection());
         }
+    }
+
+    /**
+     * @param string $operator
+     * @return string
+     */
+    protected function assertValidOperator($operator)
+    {
+        if (! in_array($operator, self::OPERATORS, true)) {
+            throw new InvalidArgumentException(sprintf(
+                'Invalid group membership operator: %s',
+                var_export($operator, true)
+            ));
+        }
+
+        return $operator;
+    }
+
+    /**
+     * The operator for a single group membership, defaults to '='
+     *
+     * @param string $name
+     * @return string
+     */
+    public function getOperator($name)
+    {
+        if (array_key_exists($name, $this->operators)) {
+            return $this->operators[$name];
+        }
+
+        return self::OP_ASSIGN;
+    }
+
+    /**
+     * Group names using exactly the given operator
+     *
+     * @param string $operator
+     * @return array
+     */
+    public function listGroupNamesForOperator($operator)
+    {
+        $this->assertValidOperator($operator);
+        $names = array();
+        foreach (array_keys($this->groups) as $name) {
+            if ($this->getOperator($name) === $operator) {
+                $names[] = $name;
+            }
+        }
+
+        return $names;
+    }
+
+    /**
+     * Group names using any of the given operators
+     *
+     * @param array $operators
+     * @return array
+     */
+    public function listGroupNamesForOperators(array $operators)
+    {
+        $names = array();
+        foreach ($operators as $operator) {
+            $names = array_merge($names, $this->listGroupNamesForOperator($operator));
+        }
+        sort($names);
+
+        return $names;
+    }
+
+    /**
+     * Groups this object ends up with, ignoring inheritance: '=' and '+=' minus '-='
+     *
+     * @return array
+     */
+    public function listEffectiveGroupNames()
+    {
+        return array_values(array_diff(
+            $this->listGroupNamesForOperators(array(self::OP_ASSIGN, self::OP_ADD)),
+            $this->listGroupNamesForOperator(self::OP_REMOVE)
+        ));
+    }
+
+    /**
+     * Stored (unmodified) group names using exactly the given operator
+     *
+     * @param string $operator
+     * @return array
+     */
+    public function listOriginalGroupNamesForOperator($operator)
+    {
+        $this->assertValidOperator($operator);
+        $names = array();
+        foreach (array_keys($this->storedGroups) as $name) {
+            $stored = array_key_exists($name, $this->storedOperators)
+                ? $this->storedOperators[$name]
+                : self::OP_ASSIGN;
+            if ($stored === $operator) {
+                $names[] = $name;
+            }
+        }
+
+        return $names;
     }
 
     #[\ReturnTypeWillChange]
@@ -92,52 +213,69 @@ class IcingaObjectGroups implements Iterator, Countable, IcingaConfigRenderer
     }
 
     /**
+     * Replace all memberships using the given operator
+     *
+     * Memberships with a different operator are left untouched, this is what
+     * allows the three group form fields (assign, add, remove) to coexist.
+     *
      * @param $group
+     * @param string $operator
      * @return $this
      * @throws NotFoundError
      */
-    public function set($group)
+    public function set($group, $operator = self::OP_ASSIGN)
     {
+        $this->assertValidOperator($operator);
+
         if (! is_array($group)) {
-            $group = array($group);
+            $group = $group === null ? array() : array($group);
         }
 
-        $existing = array_keys($this->groups);
-        $new = array();
         $class = $this->getGroupClass();
-        $unset = array();
+        $new = array();
 
-        foreach ($group as $k => $g) {
+        foreach ($group as $g) {
             if ($g instanceof $class) {
                 $new[] = $g->object_name;
-            } else {
-                if (empty($g)) {
-                    $unset[] = $k;
-                    continue;
-                }
-
+            } elseif (! empty($g)) {
                 $new[] = $g;
             }
         }
 
-        foreach ($unset as $k) {
-            unset($group[$k]);
-        }
-
+        // Compare against this operator only, otherwise an unrelated field
+        // would be able to wipe our memberships
+        $existing = $this->listGroupNamesForOperator($operator);
+        $compare = $new;
         sort($existing);
-        sort($new);
-        if ($existing === $new) {
+        sort($compare);
+        if ($existing === $compare) {
             return $this;
         }
 
-        $this->groups = array();
-        if (empty($group)) {
-            $this->modified = true;
-            $this->refreshIndex();
+        foreach ($this->listGroupNamesForOperator($operator) as $name) {
+            unset($this->groups[$name]);
+            unset($this->operators[$name]);
+        }
+
+        $this->modified = true;
+        $this->refreshIndex();
+
+        if (empty($new)) {
             return $this;
         }
 
-        return $this->add($group);
+        return $this->add($new, 'fail', $operator);
+    }
+
+    /**
+     * @param string $operator
+     * @param $group
+     * @return $this
+     * @throws NotFoundError
+     */
+    public function setForOperator($operator, $group)
+    {
+        return $this->set($group, $operator);
     }
 
     /**
@@ -154,6 +292,7 @@ class IcingaObjectGroups implements Iterator, Countable, IcingaConfigRenderer
     {
         if (array_key_exists($group, $this->groups)) {
             unset($this->groups[$group]);
+            unset($this->operators[$group]);
         }
 
         $this->modified = true;
@@ -163,22 +302,26 @@ class IcingaObjectGroups implements Iterator, Countable, IcingaConfigRenderer
     protected function refreshIndex()
     {
         ksort($this->groups);
+        ksort($this->operators);
         $this->idx = array_keys($this->groups);
     }
 
     /**
      * @param $group
      * @param string $onError
+     * @param string $operator
      * @return $this
      * @throws NotFoundError
      * @throws \Icinga\Module\Director\Exception\DuplicateKeyException
      */
-    public function add($group, $onError = 'fail')
+    public function add($group, $onError = 'fail', $operator = self::OP_ASSIGN)
     {
+        $this->assertValidOperator($operator);
+
         // TODO: only one query when adding array
         if (is_array($group)) {
             foreach ($group as $g) {
-                $this->add($g, $onError);
+                $this->add($g, $onError, $operator);
             }
             return $this;
         }
@@ -190,17 +333,21 @@ class IcingaObjectGroups implements Iterator, Countable, IcingaConfigRenderer
         /** @var IcingaObjectGroup $class */
         $class = $this->getGroupClass();
 
-        if ($group instanceof $class) {
-            if (array_key_exists($group->getObjectName(), $this->groups)) {
-                return $this;
+        $name = $group instanceof $class ? $group->getObjectName() : $group;
+
+        // Already a member? Then this might still be an operator change
+        if (is_string($name) && array_key_exists($name, $this->groups)) {
+            if ($this->getOperator($name) !== $operator) {
+                $this->operators[$name] = $operator;
+                $this->modified = true;
             }
 
+            return $this;
+        }
+
+        if ($group instanceof $class) {
             $this->groups[$group->object_name] = $group;
         } elseif (is_string($group)) {
-            if (array_key_exists($group, $this->groups)) {
-                return $this;
-            }
-
             $connection = $this->object->getConnection();
 
             try {
@@ -232,6 +379,7 @@ class IcingaObjectGroups implements Iterator, Countable, IcingaConfigRenderer
             );
         }
 
+        $this->operators[$name] = $operator;
         $this->modified = true;
         $this->refreshIndex();
 
@@ -284,6 +432,22 @@ class IcingaObjectGroups implements Iterator, Countable, IcingaConfigRenderer
 
         $class = $this->getGroupClass();
         $this->groups = $class::loadAll($connection, $query, 'object_name');
+
+        // Operators cannot ride along with the query above, loadAll() would
+        // choke on a column the group object doesn't know about
+        $operatorQuery = $db->select()->from(
+            array('go' => $table . 'group_' . $type),
+            array(
+                'group_name' => 'g.object_name',
+                'operator'   => 'go.operator',
+            )
+        )->join(
+            array('g' => $table . 'group'),
+            'go.' . $type . 'group_id = g.id',
+            array()
+        )->where('go.' . $type . '_id = ?', $this->object->id);
+
+        $this->operators = $db->fetchPairs($operatorQuery);
         $this->setBeingLoadedFromDb();
 
         return $this;
@@ -320,10 +484,34 @@ class IcingaObjectGroups implements Iterator, Countable, IcingaConfigRenderer
                 $this->getGroupMemberTableName(),
                 array(
                     $objectCol => $objectId,
-                    $groupCol => $this->groups[$group]->id
+                    $groupCol => $this->groups[$group]->id,
+                    'operator' => $this->getOperator($group)
                 )
             );
         }
+
+        // A membership that stayed, but changed its operator
+        $toUpdate = array_intersect($groups, $storedGroups);
+        foreach ($toUpdate as $group) {
+            $stored = array_key_exists($group, $this->storedOperators)
+                ? $this->storedOperators[$group]
+                : self::OP_ASSIGN;
+            $current = $this->getOperator($group);
+            if ($stored === $current) {
+                continue;
+            }
+
+            $this->object->db->update(
+                $this->getGroupMemberTableName(),
+                array('operator' => $current),
+                sprintf(
+                    $objectCol . ' = %d AND ' . $groupCol . ' = %d',
+                    $objectId,
+                    $this->groups[$group]->id
+                )
+            );
+        }
+
         $this->setBeingLoadedFromDb();
 
         return true;
@@ -336,6 +524,12 @@ class IcingaObjectGroups implements Iterator, Countable, IcingaConfigRenderer
             $this->storedGroups[$k] = clone($v);
             $this->storedGroups[$k]->id = $v->id;
         }
+
+        $this->storedOperators = $this->operators;
+
+        // loadForStoredObject() doesn't call this when prefetching, so the
+        // index would otherwise stay empty and the Iterator yield nothing
+        $this->refreshIndex();
 
         $this->modified = false;
     }
@@ -350,7 +544,9 @@ class IcingaObjectGroups implements Iterator, Countable, IcingaConfigRenderer
         $groups = new static($object);
 
         if (PrefetchCache::shouldBeUsed()) {
-            $groups->groups = PrefetchCache::instance()->groups($object);
+            $cache = PrefetchCache::instance();
+            $groups->groups = $cache->groups($object);
+            $groups->operators = $cache->groupOperators($object);
             $groups->setBeingLoadedFromDb();
         } else {
             $groups->loadFromDb();
@@ -361,25 +557,43 @@ class IcingaObjectGroups implements Iterator, Countable, IcingaConfigRenderer
 
     public function toConfigString()
     {
-        $groups = array_keys($this->groups);
+        $config = '';
 
-        if (empty($groups)) {
-            return '';
+        // '=' has to be rendered before '+=' and '-=', hence the fixed order
+        foreach (self::OPERATORS as $operator) {
+            $groups = $this->listGroupNamesForOperator($operator);
+            if (empty($groups)) {
+                continue;
+            }
+
+            $config .= c::renderKeyOperatorValue(
+                'groups',
+                $operator,
+                c::renderArray($groups)
+            );
         }
 
-        return c::renderKeyValue('groups', c::renderArray($groups));
+        return $config;
     }
 
     public function toLegacyConfigString($additionalGroups = array())
     {
-        $groups = array_merge(array_keys($this->groups), $additionalGroups);
-        $groups = array_unique($groups);
+        // Icinga 1.x knows no += / -=, so we render what the object ends up with
+        $groups = array_merge(
+            $this->listGroupNamesForOperators(array(self::OP_ASSIGN, self::OP_ADD)),
+            $additionalGroups
+        );
+        $groups = array_values(array_diff(
+            array_unique($groups),
+            $this->listGroupNamesForOperator(self::OP_REMOVE)
+        ));
 
         if (empty($groups)) {
             return '';
         }
 
         $type = $this->object->getLegacyObjectType();
+
         return c1::renderKeyValue($type . 'groups', c1::renderArray($groups));
     }
 
@@ -407,6 +621,8 @@ class IcingaObjectGroups implements Iterator, Countable, IcingaConfigRenderer
     {
         unset($this->storedGroups);
         unset($this->groups);
+        unset($this->operators);
+        unset($this->storedOperators);
         unset($this->object);
     }
 }

--- a/library/Director/Web/Form/DirectorObjectForm.php
+++ b/library/Director/Web/Form/DirectorObjectForm.php
@@ -540,6 +540,8 @@ abstract class DirectorObjectForm extends DirectorForm
             'address',
             'address6',
             'groups',
+            'groupsadd',
+            'groupsremove',
             'inherited_groups',
             'applied_groups',
             'users',
@@ -652,6 +654,55 @@ abstract class DirectorObjectForm extends DirectorForm
     {
         $this->listUrl = $url;
         return $this;
+    }
+
+    /**
+     * A group must not be listed in more than one of the group elements, the
+     * last one would silently win and the user would never learn about it
+     *
+     * @param array $data
+     * @return bool
+     */
+    public function isValid($data)
+    {
+        $valid = parent::isValid($data);
+
+        $operators = [
+            'groups'       => '=',
+            'groupsadd'    => '+=',
+            'groupsremove' => '-=',
+        ];
+
+        $seen = [];
+        foreach ($operators as $name => $operator) {
+            $element = $this->getElement($name);
+            if ($element === null) {
+                continue;
+            }
+
+            foreach ((array) $element->getValue() as $group) {
+                if ($group === null || $group === '') {
+                    continue;
+                }
+
+                if (array_key_exists($group, $seen)) {
+                    $element->addError(sprintf(
+                        $this->translate(
+                            'The group "%s" is already used with the "%s" operator,'
+                            . ' a group can only be used once'
+                        ),
+                        $group,
+                        $seen[$group]
+                    ));
+                    $valid = false;
+                    continue;
+                }
+
+                $seen[$group] = $operator;
+            }
+        }
+
+        return $valid;
     }
 
     public function onSuccess()

--- a/library/Director/Web/Table/GroupMemberTable.php
+++ b/library/Director/Web/Table/GroupMemberTable.php
@@ -126,9 +126,15 @@ class GroupMemberTable extends ZfQueryBasedTable
             ];
         }
 
+        $membership = $row->membership_type;
+        // '-=' never makes it into the resolved table, so this shows '+=' only
+        if ($row->operator !== null && $row->operator !== '=') {
+            $membership .= ' (' . $row->operator . ')';
+        }
+
         $tr->add([
             $this::td($link),
-            $this::td($row->membership_type)
+            $this::td($membership)
         ]);
 
         return $tr;
@@ -163,7 +169,8 @@ class GroupMemberTable extends ZfQueryBasedTable
             'o.id',
             'o.object_type',
             'o.object_name',
-            'membership_type' => "CASE WHEN go.{$type}_id IS NULL THEN 'apply' ELSE 'direct' END"
+            'membership_type' => "CASE WHEN go.{$type}_id IS NULL THEN 'apply' ELSE 'direct' END",
+            'operator'        => 'go.operator'
         ];
 
         if ($this->group === null) {

--- a/schema/mysql-migrations/upgrade_193.sql
+++ b/schema/mysql-migrations/upgrade_193.sql
@@ -1,0 +1,24 @@
+ALTER TABLE icinga_hostgroup_host
+  ADD COLUMN operator ENUM('=', '+=', '-=') NOT NULL DEFAULT '=';
+
+ALTER TABLE icinga_servicegroup_service
+  ADD COLUMN operator ENUM('=', '+=', '-=') NOT NULL DEFAULT '=';
+
+ALTER TABLE icinga_usergroup_user
+  ADD COLUMN operator ENUM('=', '+=', '-=') NOT NULL DEFAULT '=';
+
+ALTER TABLE branched_icinga_host
+  ADD COLUMN groupsadd TEXT DEFAULT NULL,
+  ADD COLUMN groupsremove TEXT DEFAULT NULL;
+
+ALTER TABLE branched_icinga_service
+  ADD COLUMN groupsadd TEXT DEFAULT NULL,
+  ADD COLUMN groupsremove TEXT DEFAULT NULL;
+
+ALTER TABLE branched_icinga_user
+  ADD COLUMN groupsadd TEXT DEFAULT NULL,
+  ADD COLUMN groupsremove TEXT DEFAULT NULL;
+
+INSERT INTO director_schema_migration
+  (schema_version, migration_time)
+  VALUES (193, NOW());

--- a/schema/mysql.sql
+++ b/schema/mysql.sql
@@ -979,6 +979,7 @@ CREATE TABLE icinga_servicegroup_inheritance (
 CREATE TABLE icinga_servicegroup_service (
   servicegroup_id INT(10) UNSIGNED NOT NULL,
   service_id INT(10) UNSIGNED NOT NULL,
+  operator ENUM('=', '+=', '-=') NOT NULL DEFAULT '=',
   PRIMARY KEY (servicegroup_id, service_id),
   CONSTRAINT icinga_servicegroup_service_service
     FOREIGN KEY service (service_id)
@@ -1011,6 +1012,7 @@ CREATE TABLE icinga_servicegroup_service_resolved (
 CREATE TABLE icinga_hostgroup_host (
   hostgroup_id INT(10) UNSIGNED NOT NULL,
   host_id INT(10) UNSIGNED NOT NULL,
+  operator ENUM('=', '+=', '-=') NOT NULL DEFAULT '=',
   PRIMARY KEY (hostgroup_id, host_id),
   CONSTRAINT icinga_hostgroup_host_host
     FOREIGN KEY host (host_id)
@@ -1219,6 +1221,7 @@ CREATE TABLE icinga_usergroup_inheritance (
 CREATE TABLE icinga_usergroup_user (
   usergroup_id INT(10) UNSIGNED NOT NULL,
   user_id INT(10) UNSIGNED NOT NULL,
+  operator ENUM('=', '+=', '-=') NOT NULL DEFAULT '=',
   PRIMARY KEY (usergroup_id, user_id),
   CONSTRAINT icinga_usergroup_user_user
     FOREIGN KEY icinga_user (user_id)
@@ -2010,6 +2013,8 @@ CREATE TABLE branched_icinga_host (
 
   imports TEXT DEFAULT NULL,
   `groups` TEXT DEFAULT NULL,
+  groupsadd TEXT DEFAULT NULL,
+  groupsremove TEXT DEFAULT NULL,
   vars MEDIUMTEXT DEFAULT NULL,
   set_null TEXT DEFAULT NULL,
   PRIMARY KEY (branch_uuid, uuid),
@@ -2117,6 +2122,8 @@ CREATE TABLE branched_icinga_user (
 
   imports TEXT DEFAULT NULL,
   `groups` TEXT DEFAULT NULL,
+  groupsadd TEXT DEFAULT NULL,
+  groupsremove TEXT DEFAULT NULL,
   vars MEDIUMTEXT DEFAULT NULL,
   set_null TEXT DEFAULT NULL,
   PRIMARY KEY (branch_uuid, uuid),
@@ -2304,6 +2311,8 @@ CREATE TABLE branched_icinga_service (
 
   imports TEXT DEFAULT NULL,
   `groups` TEXT DEFAULT NULL,
+  groupsadd TEXT DEFAULT NULL,
+  groupsremove TEXT DEFAULT NULL,
   vars MEDIUMTEXT DEFAULT NULL,
   set_null TEXT DEFAULT NULL,
   PRIMARY KEY (branch_uuid, uuid),
@@ -2466,4 +2475,4 @@ CREATE TABLE icinga_usergroup_user_resolved
 
 INSERT INTO director_schema_migration
   (schema_version, migration_time)
-  VALUES (192, NOW());
+  VALUES (193, NOW());

--- a/schema/pgsql-migrations/upgrade_193.sql
+++ b/schema/pgsql-migrations/upgrade_193.sql
@@ -1,0 +1,26 @@
+CREATE TYPE enum_group_membership_operator AS ENUM('=', '+=', '-=');
+
+ALTER TABLE icinga_hostgroup_host
+  ADD COLUMN operator enum_group_membership_operator NOT NULL DEFAULT '=';
+
+ALTER TABLE icinga_servicegroup_service
+  ADD COLUMN operator enum_group_membership_operator NOT NULL DEFAULT '=';
+
+ALTER TABLE icinga_usergroup_user
+  ADD COLUMN operator enum_group_membership_operator NOT NULL DEFAULT '=';
+
+ALTER TABLE branched_icinga_host
+  ADD COLUMN groupsadd TEXT DEFAULT NULL,
+  ADD COLUMN groupsremove TEXT DEFAULT NULL;
+
+ALTER TABLE branched_icinga_service
+  ADD COLUMN groupsadd TEXT DEFAULT NULL,
+  ADD COLUMN groupsremove TEXT DEFAULT NULL;
+
+ALTER TABLE branched_icinga_user
+  ADD COLUMN groupsadd TEXT DEFAULT NULL,
+  ADD COLUMN groupsremove TEXT DEFAULT NULL;
+
+INSERT INTO director_schema_migration
+  (schema_version, migration_time)
+  VALUES (193, NOW());

--- a/schema/pgsql.sql
+++ b/schema/pgsql.sql
@@ -47,6 +47,7 @@ CREATE TYPE enum_sync_state AS ENUM(
 );
 CREATE TYPE enum_host_service AS ENUM('host', 'service');
 CREATE TYPE enum_owner_type AS ENUM('user', 'usergroup', 'role');
+CREATE TYPE enum_group_membership_operator AS ENUM('=', '+=', '-=');
 CREATE DOMAIN d_smallint AS integer CHECK (VALUE >= 0) CHECK (VALUE < 65536);
 
 CREATE OR REPLACE FUNCTION unix_timestamp(timestamp with time zone) RETURNS bigint AS '
@@ -1204,6 +1205,7 @@ CREATE INDEX servicegroup_inheritance_servicegroup_parent ON icinga_servicegroup
 CREATE TABLE icinga_servicegroup_service (
   servicegroup_id integer NOT NULL,
   service_id integer NOT NULL,
+  operator enum_group_membership_operator NOT NULL DEFAULT '=',
   PRIMARY KEY (servicegroup_id, service_id),
   CONSTRAINT icinga_servicegroup_service_service
   FOREIGN KEY (service_id)
@@ -1224,6 +1226,7 @@ CREATE INDEX servicegroup_service_servicegroup ON icinga_servicegroup_service (s
 CREATE TABLE icinga_hostgroup_host (
   hostgroup_id integer NOT NULL,
   host_id integer NOT NULL,
+  operator enum_group_membership_operator NOT NULL DEFAULT '=',
   PRIMARY KEY (hostgroup_id, host_id),
   CONSTRAINT icinga_hostgroup_host_host
   FOREIGN KEY (host_id)
@@ -1454,6 +1457,7 @@ CREATE INDEX usergroup_inheritance_usergroup_parent ON icinga_usergroup_inherita
 CREATE TABLE icinga_usergroup_user (
   usergroup_id integer NOT NULL,
   user_id integer NOT NULL,
+  operator enum_group_membership_operator NOT NULL DEFAULT '=',
   PRIMARY KEY (usergroup_id, user_id),
   CONSTRAINT icinga_usergroup_user_user
   FOREIGN KEY (user_id)
@@ -2317,6 +2321,8 @@ CREATE TABLE branched_icinga_host (
 
   imports TEXT DEFAULT NULL,
   groups TEXT DEFAULT NULL,
+  groupsadd TEXT DEFAULT NULL,
+  groupsremove TEXT DEFAULT NULL,
   vars TEXT DEFAULT NULL,
 
   set_null TEXT DEFAULT NULL,
@@ -2426,6 +2432,8 @@ CREATE TABLE branched_icinga_user (
 
   imports TEXT DEFAULT NULL,
   groups TEXT DEFAULT NULL,
+  groupsadd TEXT DEFAULT NULL,
+  groupsremove TEXT DEFAULT NULL,
   vars TEXT DEFAULT NULL,
   set_null TEXT DEFAULT NULL,
   PRIMARY KEY (branch_uuid, uuid),
@@ -2626,6 +2634,8 @@ CREATE TABLE branched_icinga_service (
 
   imports TEXT DEFAULT NULL,
   groups TEXT DEFAULT NULL,
+  groupsadd TEXT DEFAULT NULL,
+  groupsremove TEXT DEFAULT NULL,
   vars TEXT DEFAULT NULL,
   set_null TEXT DEFAULT NULL,
   PRIMARY KEY (branch_uuid, uuid),
@@ -2803,4 +2813,4 @@ CREATE INDEX usergroup_user_resolved_usergroup ON icinga_usergroup_user_resolved
 
 INSERT INTO director_schema_migration
   (schema_version, migration_time)
-  VALUES (192, NOW());
+  VALUES (193, NOW());


### PR DESCRIPTION
This is a fix for #344, #636, #824, it is similar to PR [#2782](https://github.com/Icinga/icingaweb2-module-director/pull/2782), to allow Director to support the native Icinga2 group assignment operators of `=`, `+=` and `-=`.

It implements group assign (existing), group add, and group remove for hosts, services, and sync rules and provides accurate rendering of objects and resolved objects when previewing objects.

**Limitations**
This PR doesn't allow the user to change the ordering of an object. This means that objects are created and rendered in the order
* template
* group assign
* group add
* group remove

with groups inherited from templates being processed before the objects groups. 

_Important to note that the ordering of multiple templates is user defined and does have an impact on how the groups are processed._ 

**Gui**
Objects
<img width="1165" height="631" alt="image" src="https://github.com/user-attachments/assets/dbaa8650-a228-49b3-8db9-587726e5ef8d" />
Sync Rules
<img width="1039" height="348" alt="image" src="https://github.com/user-attachments/assets/90692ed6-7298-467c-af58-8e098ce1ddf0" />


**Rendering**
Template
<img width="789" height="231" alt="image" src="https://github.com/user-attachments/assets/a89ee81d-2f87-460d-b08b-60e5b7d6cf5e" />
Object View
<img width="337" height="315" alt="image" src="https://github.com/user-attachments/assets/b133706b-c200-4601-bee8-d3c794643e0f" />
Resolved Object View
<img width="330" height="237" alt="image" src="https://github.com/user-attachments/assets/b91b8745-2311-4a64-8708-d0b89bdf1ac2" />

**Implementation Notes**
This PR is based on the work in PR [#2782](https://github.com/Icinga/icingaweb2-module-director/pull/2782), though it exposes the functionality in a completely different way. AI has been used to implement and test some parts of this, followed by human testing comparing director gui, director rendered, deploy'd and `icinga2 object list` config values. 

