### PR TITLE
Permission: Drop the redundant director/* wildcard permission

### DIFF
--- a/configuration.php
+++ b/configuration.php
@@ -14,7 +14,6 @@ if ($this->getConfig()->get('frontend', 'disabled', 'no') === 'yes') {
 $monitoringExists = Module::exists('monitoring');
 $icingadbExists = Module::exists('icingadb');
 
-$this->providePermission(Permission::ALL_PERMISSIONS, $this->translate('Allow unrestricted access to Icinga Director'));
 $this->providePermission(Permission::API, $this->translate('Allow to access the director API'));
 $this->providePermission(Permission::AUDIT, $this->translate('Allow to access the full audit log'));
 $this->providePermission(Permission::DEPLOY, $this->translate('Allow to deploy configuration'));

--- a/library/Director/Auth/Permission.php
+++ b/library/Director/Auth/Permission.php
@@ -4,15 +4,14 @@ namespace Icinga\Module\Director\Auth;
 
 class Permission
 {
-    public const ALL_PERMISSIONS = 'director/*';
-    public const ADMIN = 'director/admin'; // internal, assign ALL_PERMISSONS
+    public const ADMIN = 'director/admin'; // internal, assign Full module permissions
     public const API = 'director/api';
     public const AUDIT = 'director/audit';
     public const DEPLOY = 'director/deploy';
-    public const DEPLOYMENTS = 'director/deployments'; // internal, assign ALL_PERMISSONS
+    public const DEPLOYMENTS = 'director/deployments'; // internal, assign Full module permissions
     public const GROUPS_FOR_RESTRICTED_HOSTS = 'director/groups-for-restricted-hosts';
     public const HOSTS = 'director/hosts';
-    public const HOST_GROUPS = 'director/hostgroups'; // internal, assign ALL_PERMISSIONS
+    public const HOST_GROUPS = 'director/hostgroups'; // internal, assign Full module permissions
     public const INSPECT = 'director/inspect';
     public const MONITORING_SERVICES_RO = 'director/monitoring/services-ro';
     public const MONITORING_SERVICES = 'director/monitoring/services';


### PR DESCRIPTION
Icinga Web already gives every module a "Full Module Access" option automatically, so Director didn't need to declare its own separate all-access permission on top of that. Removing it just clears out the duplicate entry.

fixes #3094 