### PR TITLE
Prevent infinite recursion when an Icinga Zone has a recursive parent relationship

### DIFF
--- a/application/forms/IcingaZoneForm.php
+++ b/application/forms/IcingaZoneForm.php
@@ -35,9 +35,10 @@ class IcingaZoneForm extends DirectorObjectForm
         $this->addElement('select', 'parent_id', array(
             'label'        => $this->translate('Parent Zone'),
             'description'  => $this->translate('Chose an (optional) parent zone'),
-            'multiOptions' => $this->optionalEnum($this->db->enumZones()),
+            'multiOptions' => $this->optionalEnum($this->db->enumZonesExcept($this->object !== null ? $this->object->get('id') : null)),
         ));
 
         $this->setButtons();
     }
 }
+

--- a/library/Director/Db.php
+++ b/library/Director/Db.php
@@ -567,6 +567,17 @@ class Db extends DbConnection
         return $this->enumIcingaObjects('zone');
     }
 
+    public function enumZonesExcept($id = null)
+    {
+        $filters = array();
+
+        if ($id !== null) {
+            $filters['id != (?)'] = (int) $id;
+        }
+
+        return $this->enumIcingaObjects('zone', $filters);
+    }
+
     public function enumNonglobalZones()
     {
         $filters = array('is_global = ?' => 'n');

--- a/library/Director/Db/Branch/BranchedObject.php
+++ b/library/Director/Db/Branch/BranchedObject.php
@@ -281,7 +281,7 @@ class BranchedObject
             }
             $branched->set('id', $this->object->get('id'));
             $branched->set('uuid', $this->object->get('uuid'));
-            foreach ((array) $this->object->toPlainObject(false, true) as $key => $value) {
+            foreach ($this->object->getProperties() as $key => $value) {
                 if ($key === 'object_type') {
                     continue;
                 }

--- a/library/Director/Objects/IcingaZone.php
+++ b/library/Director/Objects/IcingaZone.php
@@ -107,4 +107,61 @@ class IcingaZone extends IcingaObject
 
         return $this->endpointList;
     }
+    public function validate()
+    {
+        parent::validate();
+
+        $parentId = $this->get('parent_id');
+        if ($parentId === null || $parentId === '') {
+            return true;
+        }
+
+        $zoneId = $this->get('id');
+        $zoneName = $this->get('object_name');
+
+        if ($zoneId !== null && (int) $parentId === (int) $zoneId) {
+            throw new \InvalidArgumentException(sprintf(
+                'Infinite recursion detected while resolving zone graph:'
+                . ' zone "%s" cannot be its own parent. Check your zone hierarchy.',
+                $zoneName
+            ));
+        }
+
+        $path = [$zoneName];
+        $seen = [];
+        if ($zoneId !== null) {
+            $seen[(int) $zoneId] = $zoneName;
+        }
+
+        while ($parentId !== null) {
+            $parent = self::loadWithAutoIncId($parentId, $this->connection);
+            $parentName = $parent->get('object_name');
+            $path[] = $parentName;
+
+            if ($zoneId !== null && (int) $parentId === (int) $zoneId) {
+                throw new \InvalidArgumentException(sprintf(
+                    'Infinite recursion detected while resolving zone graph:'
+                    . ' setting parent to "%s" would create a cycle (%s).'
+                    . ' Check your zone hierarchy.',
+                    $path[1],
+                    implode(' -> ', $path)
+                ));
+            }
+
+            if (isset($seen[(int) $parentId])) {
+                throw new \InvalidArgumentException(sprintf(
+                    'Infinite recursion detected while resolving zone graph:'
+                    . ' pre-existing cycle in the parent chain of "%s" (%s).'
+                    . ' Check your zone hierarchy.',
+                    $zoneName,
+                    implode(' -> ', $path)
+                ));
+            }
+            $seen[(int) $parentId] = $parentName;
+
+            $parentId = $parent->get('parent_id');
+        }
+
+        return true;
+    }
 }


### PR DESCRIPTION
Resolves #3108.

This change has three parts:

1. Prevent a zone from selecting itself as its parent in `library/Director/Objects/IcingaZone.php` by introducing a new method `Db::enumZonesExcept()`. This method is essentially the exact same as the existing `Db::enumZones` method, however it adds an `$id` parameter, which is `null` by default, and if it set, adds a `$filter` when calling `enumIcingaObjects('zone')`. 

`IcingaZoneForm` uses this method to exclude the current zone from the list of available parent zones.

Another option is to just filter out the selected zone after calling `Db::enumZones`.

2. Adds `IcingaZone::validate()` to check the complete parent hierarchy when a zone is saved. This detects both a zone selecting itself directly and indirect cycles where multiple zones eventually reference one another.

3. Change `BranchedObject::getBranchedDbObject()` to use `DbObject::getProperties()` instead of `DbObject::toPlainObject()`. This prevents the parent relationship from being resolved, which otherwise causes recursive loading when a zone hierarchy contains a cycle.

Although this fixes the memory exhaustion issue, I have not tested the change for regressions in other code paths that rely on the resolved properties returned by `DbObject::toPlainObject()`.

The recursion occurs through the following call chain:
```
IcingaObject::toPlainObject()
  -> IcingaObject::getRelatedObjectName('parent')
    -> IcingaObject::loadWithAutoIncId()
      -> DbObjectStore::load()
        -> BranchedObject::getBranchedDbObject()
          -> IcingaObject::toPlainObject()
            -> ...
```

This repeatedly resolves the `parent` relationship back to the same zone until PHP exhausts the available memory.

That last change is only required if you have an existing recursive zone hierarchy - so happy for this to be cherry picked out if you think it is not necessary.

Feedback appreciated!